### PR TITLE
Add background processing for notification

### DIFF
--- a/ntfy/Info.plist
+++ b/ntfy/Info.plist
@@ -16,6 +16,8 @@
 	</dict>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>fetch</string>
+		<string>processing</string>
 		<string>remote-notification</string>
 	</array>
 </dict>

--- a/ntfy/Persistence/SubscriptionManager.swift
+++ b/ntfy/Persistence/SubscriptionManager.swift
@@ -36,6 +36,30 @@ struct SubscriptionManager {
         poll(subscription) { _ in }
     }
     
+    func backgroundPoll(_ subscription: Subscription, completionHandler: @escaping ([Message]) -> Void) {
+        let user = store.getUser(baseUrl: subscription.baseUrl!)?.toBasicUser()
+        Log.d(tag, "Polling from \(subscription.urlString()) with user \(user?.username ?? "anonymous")")
+        let backgroundConfig = URLSessionConfiguration.background(withIdentifier: "com.example.myapp.background")
+        let backgroundSession = URLSession(configuration: backgroundConfig, delegate: nil, delegateQueue: nil)
+        
+        ApiService(session: backgroundSession).poll(subscription: subscription, user: user) { messages, error in
+            guard let messages = messages else {
+                Log.e(tag, "Polling failed", error)
+                completionHandler([])
+                return
+            }
+            Log.d(tag, "Polling success, \(messages.count) new message(s)", messages)
+            if !messages.isEmpty {
+                DispatchQueue.main.sync {
+                    for message in messages {
+                        store.save(notificationFromMessage: message, withSubscription: subscription)
+                    }
+                }
+            }
+            completionHandler(messages)
+        }
+    }
+    
     func poll(_ subscription: Subscription, completionHandler: @escaping ([Message]) -> Void) {
         let user = store.getUser(baseUrl: subscription.baseUrl!)?.toBasicUser()
         Log.d(tag, "Polling from \(subscription.urlString()) with user \(user?.username ?? "anonymous")")

--- a/ntfy/Utils/ApiService.swift
+++ b/ntfy/Utils/ApiService.swift
@@ -3,9 +3,19 @@ import Foundation
 class ApiService {
     static let shared = ApiService()
     static let userAgent = "ntfy/\(Config.version) (build \(Config.build); iOS \(Config.osVersion))"
-    
+    let session: URLSession
     private let tag = "ApiService"
-    
+    let timeout = 10.0
+    init(session: URLSession? = nil) {
+        if let session {
+            self.session = session
+        } else {
+            let sessionConfig = URLSessionConfiguration.default
+            sessionConfig.timeoutIntervalForRequest = timeout
+            sessionConfig.timeoutIntervalForResource = timeout
+            self.session = URLSession(configuration: sessionConfig)
+        }
+    }
     func poll(subscription: Subscription, user: BasicUser?, completionHandler: @escaping ([Message]?, Error?) -> Void) {
         guard let url = URL(string: subscription.urlString()) else {
             // FIXME


### PR DESCRIPTION
- When app enter background mode, url request will be terminated.
- When notifications received, using background task  to poll for new notifications and display it.