### PR TITLE
Validate against trailing slash when inputting base URL

### DIFF
--- a/ntfy/Utils/Helpers.swift
+++ b/ntfy/Utils/Helpers.swift
@@ -10,7 +10,7 @@ func topicShortUrl(baseUrl: String, topic: String) -> String {
 }
 
 func topicAuthUrl(baseUrl: String, topic: String) -> String {
-    return "\(baseUrl)/\(topic)/auth"
+    return "\(topicUrl(baseUrl: baseUrl, topic: topic))/auth"
 }
 
 func topicHash(baseUrl: String, topic: String) -> String {

--- a/ntfy/Views/NotificationListView.swift
+++ b/ntfy/Views/NotificationListView.swift
@@ -149,10 +149,10 @@ struct NotificationListView: View {
                         .padding(.bottom)
                     
                     if #available(iOS 15.0, *) {
-                        Text("To send notifications to this topic, simply PUT or POST to the topic URL.\n\nExample:\n`$ curl -d \"hi\" ntfy.sh/\(subscription.topicName())`\n\nDetailed instructions are available on [ntfy.sh](https://ntfy.sh) and [in the docs](https://ntfy.sh/docs).")
+                        Text("To send notifications to this topic, simply PUT or POST to the topic URL.\n\nExample:\n`$ curl -d \"Hi\" \(shortUrl(url: subscription.urlString()))`\n\nDetailed instructions are available on [ntfy.sh](https://ntfy.sh) and [in the docs](https://ntfy.sh/docs).")
                             .foregroundColor(.gray)
                     } else {
-                        Text("To send notifications to this topic, simply PUT or POST to the topic URL.\n\nExample:\n`$ curl -d \"hi\" ntfy.sh/\(subscription.topicName())`\n\nDetailed instructions are available on https://ntfy.sh and https://ntfy.sh/docs.")
+                        Text("To send notifications to this topic, simply PUT or POST to the topic URL.\n\nExample:\n`$ curl -d \"Hi\" \(shortUrl(url: subscription.urlString()))`\n\nDetailed instructions are available on https://ntfy.sh and https://ntfy.sh/docs.")
                             .foregroundColor(.gray)
                     }
                 }

--- a/ntfy/Views/SettingsView.swift
+++ b/ntfy/Views/SettingsView.swift
@@ -116,7 +116,7 @@ struct DefaultServerView: View {
     }
     
     private func isValid() -> Bool {
-        if !newDefaultBaseUrl.isEmpty && newDefaultBaseUrl.range(of: "^https?://.+", options: .regularExpression, range: nil, locale: nil) == nil {
+        if !newDefaultBaseUrl.isEmpty && newDefaultBaseUrl.range(of: "^https?://.+[^/]$", options: .regularExpression, range: nil, locale: nil) == nil {
             return false
         }
         return true
@@ -243,7 +243,7 @@ struct UserTableView: View {
     
     private func isValid() -> Bool {
         if selectedUser == nil { // New user
-            if baseUrl.range(of: "^https?://.+", options: .regularExpression, range: nil, locale: nil) == nil {
+            if baseUrl.range(of: "^https?://.+[^/]$", options: .regularExpression, range: nil, locale: nil) == nil {
                 return false
             } else if username.isEmpty || password.isEmpty {
                 return false

--- a/ntfy/Views/SubscriptionAddView.swift
+++ b/ntfy/Views/SubscriptionAddView.swift
@@ -134,7 +134,7 @@ struct SubscriptionAddView: View {
             return false
         } else if sanitizedTopic.range(of: "^[-_A-Za-z0-9]{1,64}$", options: .regularExpression, range: nil, locale: nil) == nil {
             return false
-        } else if selectedBaseUrl.range(of: "^https?://.+", options: .regularExpression, range: nil, locale: nil) == nil {
+        } else if selectedBaseUrl.range(of: "^https?://.+[^/]$", options: .regularExpression, range: nil, locale: nil) == nil {
             return false
         } else if store.getSubscription(baseUrl: selectedBaseUrl, topic: topic) != nil {
             return false


### PR DESCRIPTION
Validate the input in several areas for a trailing slash to prevent a trailing slash in the baseUrl from causing errors later on:
![image](https://github.com/binwiederhier/ntfy-ios/assets/144067488/2c39f371-d03d-4e95-98bf-ca14874dc91c)

![image](https://github.com/binwiederhier/ntfy-ios/assets/144067488/bed06a46-7ffc-4b5e-a187-cabe1a6758dd)
