### PR TITLE
Configurable Xcode configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 .DS_Store
+
+# build-specific config override file
+projectoverride.xcconfig
+
 GoogleService-Info.plist
+
 ntfy.xcodeproj/xcuserdata
 ntfy.xcodeproj/project.xcworkspace/xcuserdata/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 #  ntfy iOS App
+
 This is the iOS app for [ntfy](https://github.com/binwiederhier/ntfy) ([ntfy.sh](https://ntfy.sh)).
 
 ## Relevant Links
@@ -8,11 +9,13 @@ This is the iOS app for [ntfy](https://github.com/binwiederhier/ntfy) ([ntfy.sh]
 - [Technical Limitations](docs/TECHNICAL_LIMITATIONS.md)
 
 ## Contact me
+
 You can directly contact me **[on Discord](https://discord.gg/cT7ECsZj9w)** or [on Matrix](https://matrix.to/#/#ntfy:matrix.org) 
 (bridged from Discord), or via the [GitHub issues](https://github.com/binwiederhier/ntfy/issues), or find more contact information
 [on my website](https://heckel.io/about).
 
 ## License
+
 Originally developed by [@Copephobia](https://github.com/Copephobia). He did the bulk of the work, and deserves most
 of the credit. Thank you @Copephobia!
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,23 +1,51 @@
 # ntfy.sh iOS - Getting Started with Development
 
+Building the iOS app is very involved. Please report any inconsistencies or issues with it. The requirements are
+strictly based off of my development on this app. There may be other versions of macOS / XCode that work.
+
 ## Requirements
-Note: these requirements are strictly based off of my development on this app. There may be other versions of macOS / XCode that work. Feel free to test on other versions!
 
 1. macOS Monterey or later
 1. XCode 13.2+
-1. A physical iOS device (for push notifications, I could not get them to work in the XCode simulator)
-1. The [macOS development branch for ntfy](https://github.com/Copephobia/ntfy/tree/macos-development) (for APNS configuration)
+1. A physical iOS device (for push notifications, Firebase does not work in the XCode simulator)
 1. Firebase account
-1. Apple Developer license? (I forget if its possible to do testing without purchasing the license)
+1. Apple Developer license? (I forget if it's possible to do testing without purchasing the license)
 
-## Setup - Apple Developer
+## Apple setup
+
+> [!NOTE]
+> Along with this step, the [PLIST Deployment](#plist-deployment-and-configuration) step is also required
+> for these changes to take effect in the iOS app.
 
 1. [Create a new key in Apple Developer Member Center](https://developer.apple.com/account/resources/authkeys/add)
   1. Select "Apple Push Notifications service (APNs)"
 1. Download the newly created key (should have a file name similar to `AuthKey_ZZZZZZ.p8`, where `ZZZZZZ` is the **Key ID**)
 1. Record your **Team ID** - it can be seen in the top-right corner of the page, or on your Account > Membership page
+1. Next, navigate to "Project Settings" in the firebase console for your project, and select the iOS app you created. Then, click "Cloud Messaging" in the left sidebar, and
+scroll down to the "APNs Authentication Key" section. Click "Upload Key", and upload the key you downloaded from Apple Developer.
 
-## Setup - Firebase
+> [!IMPORTANT]
+> If you don't do the above setups for APNS, **notifications will not post instantly or sometimes at all**. This is because of the missing APNS key, which is required for
+> firebase to send notifications to the iOS app. See below for a snip from the firebase docs.
+
+If you don't have an APNs authentication key, you can still send notifications to iOS devices, but they won't be delivered
+instantly. Instead, they'll be delivered when the device wakes up to check for new notifications or when your application
+sends a firebase request to check for them. The time to check for new notifications can vary from a few seconds to hours,
+days or even weeks. Enabling APNs authentication keys ensures that notifications are delivered instantly and is strongly
+recommended.
+
+## ntfy-ios Git repository
+
+1. Clone the repository: `git clone git@github.com:binwiederhier/ntfy-ios.git`
+1. change directory to the git repository: `cd ntfy-ios`
+1. Write your personal configs to `projectoverride.xcconfig`
+  1. Copy the reference `projectoverride.xcconfig` file: `cp projectoverride.xcconfig.dist projectoverride.xcconfig`
+  1. Enter your Apple Team ID for value `DEVELOPMENT_TEAM`
+  1. (optional) Uncomment Project Bundle variables and update your preferred Apple Project Bundle ID for value `PRODUCT_BUNDLE_IDENTIFIER_OVERRIDE`
+  1. (optional) Uncomment Group ID variables and update your preferred App Group ID for value `APP_GROUP_ID_OVERRIDE`
+
+
+## Firebase setup
 
 1. If you haven't already, create a Google / Firebase account
 1. Visit the [Firebase console](https://console.firebase.google.com)
@@ -25,27 +53,44 @@ Note: these requirements are strictly based off of my development on this app. T
   1. Enter a project name
   1. Disable Google Analytics (currently iOS app does not support analytics)
 1. On the "Project settings" page, add an iOS app
-  1. Apple bundle ID - "com.copephobia.ntfy-ios" (this can be changed to match XCode's ntfy.sh target > "Bundle Identifier" value)
+  1. Apple bundle ID - "com.copephobia.ntfy-ios" (this can be changed to match yours as shown in XCode's ntfy.sh target > "Bundle Identifier")
   1. Register the app
   1. Download the config file - GoogleInfo.plist (this will need to be included in the ntfy-ios repository / XCode)
 1. Generate a new service account private key for the ntfy server
   1. Go to "Project settings" > "Service accounts"
   1. Click "Generate new private key" to generate and download a private key to use for sending messages via the ntfy server
 
-## Setup - ntfy server
 
-1. Checkout the [macOS development branch for ntfy](https://github.com/Copephobia/ntfy/tree/macos-development)
+## ntfy server
+
+> [!NOTE]
+> The ntfy server is not officially supported on macOS.
+> It should, however, be able to run on macOS using these steps:
+
 1. If not already made, make the `/etc/ntfy/` directory and move the service account private key to that folder
 1. Copy the `server/server.yml` file from the ntfy repository to `/etc/ntfy/`
 1. Modify the `/etc/ntfy/server.yml` file `firebase-key-file` value to the path of the private key
 1. Install go: `brew install go`
-1. In the ntfy repository, run `make build-simple`
+1. In the ntfy repository, run `make cli-darwin-server`.
 
-## Setup - XCode
+## XCode setup
 
-1. Follow step 4 of [https://firebase.google.com/docs/ios/setup](Add Firebase to your Apple project) to install the firebase-ios-sdk in XCode, if it's not already present - you can select any packages in addition to Firebase Core / Firebase Messaging
+1. Follow step 4 of [Add Firebase to your Apple project](https://firebase.google.com/docs/ios/setup) to install the
+   `firebase-ios-sdk` in XCode, if it's not already present - you can select any packages in addition to Firebase Core / Firebase Messaging
 1. Similarly, install the SQLite.swift package dependency in XCode
 1. When running the debug build, ensure XCode is pointed to the connected iOS device - registering for push notifications does not work in the iOS simulators
+
+## PLIST config
+
+To have instant notifications/better notification delivery when using firebase, you will need to add the
+`GoogleService-Info.plist` file to your project. Here's how to do that:
+
+1. In XCode, find the `ntfy` app target. note: this is **not** the `ntfyNSE` app target.
+1. Find the `Asset/` folder in the project navigator
+1. Drag the `GoogleService-Info.plist` file into the `Asset/` folder that you get from the firebase console. It can be
+   found in the "Project settings" > "General" > "Your apps"  with a button labled "GoogleService-Info.plist"
+
+After that, you should be all set!
 
 ## Useful resources
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -53,7 +53,7 @@ recommended.
   1. Enter a project name
   1. Disable Google Analytics (currently iOS app does not support analytics)
 1. On the "Project settings" page, add an iOS app
-  1. Apple bundle ID - "com.copephobia.ntfy-ios" (this can be changed to match yours as shown in XCode's ntfy.sh target > "Bundle Identifier")
+  1. Apple bundle ID - "io.heckel.ntfy" (this can be changed to match yours as shown in XCode's ntfy.sh target > "Bundle Identifier")
   1. Register the app
   1. Download the config file - GoogleInfo.plist (this will need to be included in the ntfy-ios repository / XCode)
 1. Generate a new service account private key for the ntfy server

--- a/ntfy.xcodeproj/project.pbxproj
+++ b/ntfy.xcodeproj/project.pbxproj
@@ -115,6 +115,8 @@
 		94CD1969283E666900973B93 /* EmojiManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmojiManager.swift; sourceTree = "<group>"; };
 		E270080F2AF0F64B006E33BA /* SubscriptionsObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionsObservable.swift; sourceTree = "<group>"; };
 		E27008112AF1030A006E33BA /* NotificationsObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsObservable.swift; sourceTree = "<group>"; };
+		F4DF34D42B4E9FD20019295A /* project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = project.xcconfig; sourceTree = "<group>"; };
+		F4DF34D52B4EAB120019295A /* projectoverride.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = projectoverride.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -139,6 +141,8 @@
 		9474F1B4282F2AA700CDE4DD = {
 			isa = PBXGroup;
 			children = (
+				F4DF34D52B4EAB120019295A /* projectoverride.xcconfig */,
+				F4DF34D42B4E9FD20019295A /* project.xcconfig */,
 				9474F1BF282F2AA700CDE4DD /* ntfy */,
 				9474F1E5282F3FFD00CDE4DD /* ntfyNSE */,
 				9474F1BE282F2AA700CDE4DD /* Products */,
@@ -428,6 +432,7 @@
 /* Begin XCBuildConfiguration section */
 		9474F1C9282F2AA800CDE4DD /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F4DF34D42B4E9FD20019295A /* project.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				APP_BASE_URL = "https://ntfy.sh";
@@ -489,6 +494,7 @@
 		};
 		9474F1CA282F2AA800CDE4DD /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F4DF34D42B4E9FD20019295A /* project.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				APP_BASE_URL = "https://ntfy.sh";
@@ -552,7 +558,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_ASSET_PATHS = "\"ntfy/Assets/Preview Content\"";
-				DEVELOPMENT_TEAM = YXQ4AMS4B4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ntfy/Info.plist;
@@ -568,7 +573,6 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.3;
-				PRODUCT_BUNDLE_IDENTIFIER = io.heckel.ntfy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -586,7 +590,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_ASSET_PATHS = "\"ntfy/Assets/Preview Content\"";
-				DEVELOPMENT_TEAM = YXQ4AMS4B4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ntfy/Info.plist;
@@ -602,7 +605,6 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.3;
-				PRODUCT_BUNDLE_IDENTIFIER = io.heckel.ntfy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/ntfy/ntfy.entitlements
+++ b/ntfy/ntfy.entitlements
@@ -6,7 +6,7 @@
 	<string>development</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.io.heckel.ntfy</string>
+		<string>$(APP_GROUP_ID)</string>
 	</array>
 </dict>
 </plist>

--- a/project.xcconfig
+++ b/project.xcconfig
@@ -1,0 +1,22 @@
+//
+//  project.xcconfig
+//  ntfy
+//
+//  Created by dacodedbeat on 1/10/24.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+DEVELOPMENT_TEAM = ##TEAM_ID##
+
+PRODUCT_BUNDLE_IDENTIFIER_CONFIG = DEFAULT
+APP_GROUP_ID_CONFIG = DEFAULT
+
+#include? "projectoverride.xcconfig"
+
+PRODUCT_BUNDLE_IDENTIFIER_DEFAULT = com.$(DEVELOPMENT_TEAM).ntfy
+PRODUCT_BUNDLE_IDENTIFIER = $(PRODUCT_BUNDLE_IDENTIFIER_$(PRODUCT_BUNDLE_IDENTIFIER_CONFIG))
+
+APP_GROUP_ID_DEFAULT = group.$(PRODUCT_BUNDLE_IDENTIFIER)
+APP_GROUP_ID = $(APP_GROUP_ID_$(APP_GROUP_ID_CONFIG))

--- a/projectoverride.xcconfig.dist
+++ b/projectoverride.xcconfig.dist
@@ -1,0 +1,22 @@
+//
+//  projectoverride.xcconfig
+//  ntfy
+//
+//  Created by dacodedbeat on 1/10/24.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+// note: DEVELOPMENT_TEAM is required
+DEVELOPMENT_TEAM = YXQ4AMS4B4
+
+//// uncomment this and edit if you want to use a different PRODUCT_BUNDLE_IDENTIFIER scheme
+////   note: production currently needs this
+//PRODUCT_BUNDLE_IDENTIFIER_CONFIG = OVERRIDE
+//PRODUCT_BUNDLE_IDENTIFIER_OVERRIDE = io.heckel.ntfy
+
+//// uncomment this and edit if you want to use a different APP_GROUP_ID scheme
+////   note: production currently does not need this
+//APP_GROUP_ID_CONFIG = OVERRIDE
+//APP_GROUP_ID_OVERRIDE = group.io.heckel.ntfy


### PR DESCRIPTION
Rather than futzing around with the shared project config and hoping that personal configs are not accidentally merged, this PR shifts configuration to a `project.xcconfig` and `projectoverride.xcconfig` file, where `project.xcconfig` provides default values and `projectoverride.xcconfig` is user-defined for their deployments.

Steps on how to configure the app is outlined in `docs/GETTING_STARTED.md`, as before, and the newer docs from the `ntfy` repo (https://github.com/binwiederhier/ntfy/blob/main/docs/develop.md#ios-app) have been combined with the previous docs here.