### PR TITLE
Fix subscription lookup by topic instead of URL hash

### DIFF
--- a/ntfyNSE/NotificationService.swift
+++ b/ntfyNSE/NotificationService.swift
@@ -66,7 +66,7 @@ class NotificationService: UNNotificationServiceExtension {
     }
     
     private func handlePollRequest(_ request: UNNotificationRequest, _ content: UNMutableNotificationContent, _ pollRequest: Message, _ contentHandler: @escaping (UNNotificationContent) -> Void) {
-        let subscription = store?.getSubscriptions()?.first { $0.urlHash() == pollRequest.topic }
+        let subscription = store?.getSubscriptions()?.first { $0.topic == pollRequest.topic }
         let baseUrl = subscription?.baseUrl
         guard
             let subscription = subscription,


### PR DESCRIPTION
Previously, the subscription lookup compared pollRequest.topic (a single string) with urlHash(), which includes both baseUrl and topic, causing the lookup to always fail. This change updates the comparison to directly match subscription.topic with pollRequest.topic to ensure correct behavior.