### PR TITLE
Enable time-sensitive and critical notifications

### DIFF
--- a/ntfy/App/AppDelegate.swift
+++ b/ntfy/App/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ObservableObject {
         UNUserNotificationCenter.current().delegate = self
         Messaging.messaging().delegate = self
         
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { success, error in
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound, .timeSensitive, .criticalAlert]) { success, error in
             guard success else {
                 Log.e(self.tag, "Failed to register for local push notifications", error)
                 return

--- a/ntfy/App/AppDelegate.swift
+++ b/ntfy/App/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ObservableObject {
         UNUserNotificationCenter.current().delegate = self
         Messaging.messaging().delegate = self
         
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound, .timeSensitive, .criticalAlert]) { success, error in
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { success, error in
             guard success else {
                 Log.e(self.tag, "Failed to register for local push notifications", error)
                 return

--- a/ntfy/ntfy.entitlements
+++ b/ntfy/ntfy.entitlements
@@ -10,7 +10,5 @@
 	</array>
 	<key>com.apple.developer.usernotifications.time-sensitive</key>
 	<true/>
-	<key>com.apple.developer.usernotifications.critical</key>
-	<true/>
 </dict>
 </plist>

--- a/ntfy/ntfy.entitlements
+++ b/ntfy/ntfy.entitlements
@@ -8,5 +8,9 @@
 	<array>
 		<string>group.io.heckel.ntfy</string>
 	</array>
+	<key>com.apple.developer.usernotifications.time-sensitive</key>
+	<true/>
+	<key>com.apple.developer.usernotifications.critical</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Existing code (https://github.com/binwiederhier/ntfy-ios/blob/3feb27848acb01a3885828e37ff64c939e3f39ba/ntfy/Utils/NotificationContent.swift#L62) already attempts to send timeSensitive and critical alerts to the user. But without the proper entitlement, the notification has normal priority. 

Time-sensitive notifications are critical for breaking through the user's Focus mode (do not disturb, focus on work). 

Critical notifications are only needed if you want to bypass the ringer switch (e.g., audible alert despite silent mode).