### PR TITLE
Token login

### DIFF
--- a/ntfy/Views/SettingsView.swift
+++ b/ntfy/Views/SettingsView.swift
@@ -4,7 +4,7 @@ import StoreKit
 
 struct SettingsView: View {
     @EnvironmentObject private var store: Store
-    
+
     var body: some View {
         NavigationView {
             Form {
@@ -133,7 +133,8 @@ struct UserTableView: View {
     
     @State private var selectedUser: User?
     @State private var showDialog = false
-    
+    @State private var useToken: Bool = false
+
     @State private var baseUrl: String = ""
     @State private var username: String = ""
     @State private var password: String = ""
@@ -147,6 +148,12 @@ struct UserTableView: View {
                     baseUrl = user.baseUrl ?? "?"
                     username = user.username ?? "?"
                     showDialog = true
+                    
+                    if user.username == "" && user.password != "" {
+                        useToken = true
+                        password = user.password ?? "?"
+                    }
+                    
                 }) {
                     UserRowView(user: user)
                         .foregroundColor(.primary)
@@ -164,22 +171,36 @@ struct UserTableView: View {
             .padding(.all, 4)
         }
         .sheet(isPresented: $showDialog) {
+            
             NavigationView {
                 Form {
                     Section(
-                        footer: (selectedUser == nil)
-                        ? Text("You can add a user here. All topics for the given server will use this user.")
-                        : Text("Edit the username or password for \(shortUrl(url: baseUrl)) here. This user is used for all topics of this server. Leave the password blank to leave it unchanged.")
                     ) {
                         if selectedUser == nil {
                             TextField("Service URL, e.g. https://ntfy.home.io", text: $baseUrl)
                                 .disableAutocapitalization()
                                 .disableAutocorrection(true)
                         }
-                        TextField("Username", text: $username)
-                            .disableAutocapitalization()
-                            .disableAutocorrection(true)
-                        SecureField("Password", text: $password)
+                    }
+                    Section(
+                    ) {
+                        Toggle("Authenticate using a token", isOn: $useToken)
+                    }
+                    Section(
+                        footer: (selectedUser == nil)
+                        ? Text("You can add a user here. All topics for the given server will use this user.")
+                        : Text("Edit the username or password for \(shortUrl(url: baseUrl)) here. This user is used for all topics of this server. Leave the password blank to leave it unchanged.")
+                    ) {
+                        if useToken {
+                            TextField("Token value", text: $password)
+                                .disableAutocapitalization()
+                                .disableAutocorrection(true)
+                        } else {
+                            TextField("Username", text: $username)
+                                .disableAutocapitalization()
+                                .disableAutocorrection(true)
+                            SecureField("Password", text: $password)
+                        }
                     }
                 }
                 .navigationTitle(selectedUser == nil ? "Add user" : "Edit user")
@@ -228,6 +249,10 @@ struct UserTableView: View {
         if let user = selectedUser, password == "" {
             password = user.password ?? "?" // If password is blank, leave unchanged
         }
+        var username = username
+        if useToken {
+            username = "" // If using a token to log in, ensure username is blank
+        }
         store.saveUser(baseUrl: baseUrl, username: username, password: password)
         resetAndHide()
     }
@@ -245,13 +270,17 @@ struct UserTableView: View {
         if selectedUser == nil { // New user
             if baseUrl.range(of: "^https?://.+", options: .regularExpression, range: nil, locale: nil) == nil {
                 return false
-            } else if username.isEmpty || password.isEmpty {
+            } else if useToken && password.isEmpty {
+                return false
+            } else if !useToken && (username.isEmpty || password.isEmpty) {
                 return false
             } else if store.getUser(baseUrl: baseUrl) != nil {
                 return false
             }
         } else { // Existing user
-            if username.isEmpty {
+            if useToken && password.isEmpty {
+                return false
+            } else if username.isEmpty {
                 return false
             }
         }
@@ -266,6 +295,7 @@ struct UserTableView: View {
             baseUrl = ""
             username = ""
             password = ""
+            useToken = false
         }
     }
 }

--- a/ntfy/Views/SubscriptionAddView.swift
+++ b/ntfy/Views/SubscriptionAddView.swift
@@ -13,7 +13,8 @@ struct SubscriptionAddView: View {
     @State private var showLogin: Bool = false
     @State private var username: String = ""
     @State private var password: String = ""
-    
+    @State private var useToken: Bool = false
+
     @State private var loading = false
     @State private var addError: String?
     @State private var loginError: String?
@@ -93,15 +94,25 @@ struct SubscriptionAddView: View {
     }
     
     private var loginView: some View {
+        
         VStack(alignment: .leading, spacing: 0) {
             Form {
+                Section () {
+                    Toggle("Authenticate using a token", isOn: $useToken)
+                }
                 Section(
-                    footer: Text("This topic requires that you log in with username and password. The user will be stored on your device, and will be re-used for other topics.")
+                    footer: Text("This topic requires that you log in with " + (useToken ? "a token" : "username and password") + ". The user will be stored on your device, and will be re-used for other topics.")
                 ) {
-                    TextField("Username", text: $username)
-                        .disableAutocapitalization()
-                        .disableAutocorrection(true)
-                    SecureField("Password", text: $password)
+                    if useToken {
+                        TextField("Token", text: $password)
+                            .disableAutocapitalization()
+                            .disableAutocorrection(true)
+                    } else {
+                        TextField("Username", text: $username)
+                            .disableAutocapitalization()
+                            .disableAutocorrection(true)
+                        SecureField("Password", text: $password)
+                    }
                 }
             }
             if let error = loginError {
@@ -143,7 +154,9 @@ struct SubscriptionAddView: View {
     }
     
     private func isLoginViewValid() -> Bool {
-        if username.isEmpty || password.isEmpty {
+        if useToken && password.isEmpty {
+            return false
+        } else if !useToken && (username.isEmpty || password.isEmpty) {
             return false
         }
         return true


### PR DESCRIPTION
Added some UI enhancements to allow users to be added with tokens rather than username/password.

Behind the UI changes, this allows a User with a blank username, and saves the token into the password field. This means that it works out-of-the-box with ntfy's ability to use a blank username/token to authenticate using basic auth.

Screenshots of the UI updates attached.

Settings view:
![87AD238B-1DF3-476A-8040-C26393672A4C_4_5005_c](https://github.com/user-attachments/assets/92c6b617-7c47-483c-9cbc-3a7fbd2f75a6)

Add User view, username/password:
![A440772D-D8F0-415D-9FE4-D5404CEDFE14_4_5005_c](https://github.com/user-attachments/assets/4bf668d9-217f-4091-bf4c-935b1af4a881)

Add User view, 'login with token' selected:
![5994F574-E567-4DF7-9674-B5F8CAA1C1C6_4_5005_c](https://github.com/user-attachments/assets/f3e73610-cd64-4c16-97f6-c67a5d54cbc6)

Login Required view (when subscribing to a topic), username/password:
![2B0B0A85-1181-49D3-AF2D-BD3A2228048A_4_5005_c](https://github.com/user-attachments/assets/cb5378b2-20f0-42a8-9eb9-c68944028380)

Login Required view (when subscribing to a topic), 'login with token' selected:
![C67D7B7E-EDAE-4AD6-B8D7-C5BF5A4EF69F_4_5005_c](https://github.com/user-attachments/assets/fa494f1c-6812-483b-bf75-7892afd5547f)
