### PR TITLE
Adding an 'unread notification' indicator and unread count badge to the app icon

### DIFF
--- a/ntfy.xcodeproj/project.pbxproj
+++ b/ntfy.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		94CD1969283E666900973B93 /* EmojiManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmojiManager.swift; sourceTree = "<group>"; };
 		E270080F2AF0F64B006E33BA /* SubscriptionsObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionsObservable.swift; sourceTree = "<group>"; };
 		E27008112AF1030A006E33BA /* NotificationsObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsObservable.swift; sourceTree = "<group>"; };
+		FE2A6BD32E2AE531003B622C /* Model 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 2.xcdatamodel"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -719,9 +720,10 @@
 		9474F1F52830830700CDE4DD /* ntfy.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				FE2A6BD32E2AE531003B622C /* Model 2.xcdatamodel */,
 				9474F1F62830830700CDE4DD /* Model.xcdatamodel */,
 			);
-			currentVersion = 9474F1F62830830700CDE4DD /* Model.xcdatamodel */;
+			currentVersion = FE2A6BD32E2AE531003B622C /* Model 2.xcdatamodel */;
 			path = ntfy.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/ntfy/Persistence/Store.swift
+++ b/ntfy/Persistence/Store.swift
@@ -119,6 +119,7 @@ class Store: ObservableObject {
             notification.actions = Actions.shared.encode(message.actions)
             notification.click = message.click ?? ""
             notification.subscription = subscription
+            notification.unread = true
             subscription.addToNotifications(notification)
             subscription.lastNotificationId = message.id
             Log.d(Store.tag, "Storing notification with ID \(notification.id ?? "<unknown>")")
@@ -237,6 +238,16 @@ class Store: ObservableObject {
             Log.w(Store.tag, "Cannot mark notifications as read", error)
             rollbackAndRefresh()
         }
+    }
+    
+    var totalUnreadNotificationCount: Int {
+        var count: Int = 0
+        if let subscriptions = getSubscriptions() {
+            for subscription in subscriptions {
+                count += subscription.unreadNotificationCount()
+            }
+        }
+        return count
     }
 }
 

--- a/ntfy/Persistence/Store.swift
+++ b/ntfy/Persistence/Store.swift
@@ -215,6 +215,29 @@ class Store: ObservableObject {
         request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [NSPredicate(format: "key = %@", key)])
         return try? context.fetch(request).first
     }
+    
+    // MARK: Read / unread status
+    
+    func toggleRead(forNotification notification: Notification) {
+        notification.unread = !notification.unread
+        try? context.save()
+    }
+    
+    func markAsRead(allNotificationsFor subscription: Subscription) {
+        guard let notifications = subscription.notifications else { return }
+        Log.d(Store.tag, "Marking all \(notifications.count) notification(s) for subscription \(subscription.urlString()) as read")
+        do {
+            notifications.forEach { notification in
+                if let notification = notification as? Notification {
+                    notification.unread = false
+                }
+            }
+            try context.save()
+        } catch let error {
+            Log.w(Store.tag, "Cannot mark notifications as read", error)
+            rollbackAndRefresh()
+        }
+    }
 }
 
 extension Store {

--- a/ntfy/Persistence/Subscription.swift
+++ b/ntfy/Persistence/Subscription.swift
@@ -21,6 +21,10 @@ extension Subscription {
         return notifications?.count ?? 0
     }
     
+    func unreadNotificationCount() -> Int {
+        return notifications?.count(where: { ($0 as! Notification).unread }) ?? 0
+    }
+    
     func lastNotification() -> Notification? {
         return notificationsSorted().first
     }

--- a/ntfy/Persistence/ntfy.xcdatamodeld/.xccurrentversion
+++ b/ntfy/Persistence/ntfy.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_XCCurrentVersionName</key>
+	<string>Model 2.xcdatamodel</string>
+</dict>
+</plist>

--- a/ntfy/Persistence/ntfy.xcdatamodeld/Model 2.xcdatamodel/contents
+++ b/ntfy/Persistence/ntfy.xcdatamodeld/Model 2.xcdatamodel/contents
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24F74" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Notification" representedClassName="Notification" syncable="YES" codeGenerationType="class">
+        <attribute name="actions" optional="YES" attributeType="String"/>
+        <attribute name="click" optional="YES" attributeType="String"/>
+        <attribute name="id" attributeType="String"/>
+        <attribute name="message" attributeType="String"/>
+        <attribute name="priority" optional="YES" attributeType="Integer 16" minValueString="1" maxValueString="5" defaultValueString="3" usesScalarValueType="YES"/>
+        <attribute name="tags" optional="YES" attributeType="String"/>
+        <attribute name="time" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="unread" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <relationship name="subscription" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Subscription" inverseName="notifications" inverseEntity="Subscription"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="id"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="Preference" representedClassName="Preference" syncable="YES" codeGenerationType="class">
+        <attribute name="key" optional="YES" attributeType="String"/>
+        <attribute name="value" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="Subscription" representedClassName="Subscription" syncable="YES" codeGenerationType="class">
+        <attribute name="baseUrl" attributeType="String"/>
+        <attribute name="lastNotificationId" optional="YES" attributeType="String"/>
+        <attribute name="topic" attributeType="String" minValueString="1" maxValueString="64" regularExpressionString="^[-_A-Za-z0-9]{1,64}$"/>
+        <relationship name="notifications" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Notification" inverseName="subscription" inverseEntity="Notification"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="baseUrl"/>
+                <constraint value="topic"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="User" representedClassName="User" syncable="YES" codeGenerationType="class">
+        <attribute name="baseUrl" attributeType="String"/>
+        <attribute name="password" attributeType="String"/>
+        <attribute name="username" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="baseUrl"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+</model>

--- a/ntfy/Views/NotificationListView.swift
+++ b/ntfy/Views/NotificationListView.swift
@@ -86,6 +86,12 @@ struct NotificationListView: View {
                         Button("Send test notification") {
                             self.sendTestNotification()
                         }
+                        if notificationsModel.notifications.count(where: { $0.unread }) > 0 {
+                            Button("Mark all as read") {
+                                self.showAlert = true
+                                self.activeAlert = .readAll
+                            }
+                        }
                         if notificationsModel.notifications.count > 0 {
                             Button("Clear all notifications") {
                                 self.showAlert = true
@@ -268,69 +274,72 @@ struct NotificationRowView: View {
     }
     
     private var notificationRow: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            HStack(alignment: .center, spacing: 2) {
-                Text(notification.shortDateTime())
-                    .font(.subheadline)
-                    .foregroundColor(.gray)
-                if [1,2,4,5].contains(notification.priority) {
-                    Image("priority-\(notification.priority)")
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 16, height: 16)
+        HStack(alignment: .center, spacing: 0) {
+            Circle()
+                .fill(notification.unread ? .blue : .clear)
+                .frame(width: 8, height: 8)
+                .padding(.trailing, 8) // Add some space between the dot and the text
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(alignment: .center, spacing: 2) {
+                    Text(notification.shortDateTime())
+                        .font(.subheadline)
+                        .foregroundColor(.gray)
+                    if [1,2,4,5].contains(notification.priority) {
+                        Image("priority-\(notification.priority)")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 16, height: 16)
+                    }
                 }
-            }
-            .padding([.bottom], 2)
-            if let title = notification.formatTitle(), title != "" {
-                Text(title)
-                    .font(.headline)
-                    .bold()
-                    .padding([.bottom], 2)
-            }
-            Text(notification.formatMessage())
-                .font(.body)
-            if !notification.nonEmojiTags().isEmpty {
-                Text("Tags: " + notification.nonEmojiTags().joined(separator: ", "))
-                    .font(.subheadline)
-                    .foregroundColor(.gray)
-                    .padding([.top], 2)
-            }
-            if !notification.actionsList().isEmpty {
-                HStack {
-                    ForEach(notification.actionsList()) { action in
-                        if #available(iOS 15, *) {
-                            Button(action.label) {
-                                ActionExecutor.execute(action)
+                .padding([.bottom], 2)
+                if let title = notification.formatTitle(), title != "" {
+                    Text(title)
+                        .font(.headline)
+                        .bold()
+                        .padding([.bottom], 2)
+                }
+                Text(notification.formatMessage())
+                    .font(.body)
+                if !notification.nonEmojiTags().isEmpty {
+                    Text("Tags: " + notification.nonEmojiTags().joined(separator: ", "))
+                        .font(.subheadline)
+                        .foregroundColor(.gray)
+                        .padding([.top], 2)
+                }
+                if !notification.actionsList().isEmpty {
+                    HStack {
+                        ForEach(notification.actionsList()) { action in
+                            if #available(iOS 15, *) {
+                                Button(action.label) {
+                                    ActionExecutor.execute(action)
+                                }
+                                .buttonStyle(.borderedProminent)
+                            } else {
+                                Button(action: {
+                                    ActionExecutor.execute(action)
+                                }) {
+                                    Text(action.label)
+                                        .padding(EdgeInsets(top: 10.0, leading: 10.0, bottom: 10.0, trailing: 10.0))
+                                        .foregroundColor(.white)
+                                        .overlay(
+                                            RoundedRectangle(cornerRadius: 10)
+                                                .stroke(Color.white, lineWidth: 2)
+                                        )
+                                }
+                                .background(Color.accentColor)
+                                .cornerRadius(10)
                             }
-                            .buttonStyle(.borderedProminent)
-                        } else {
-                            Button(action: {
-                                ActionExecutor.execute(action)
-                            }) {
-                                Text(action.label)
-                                    .padding(EdgeInsets(top: 10.0, leading: 10.0, bottom: 10.0, trailing: 10.0))
-                                    .foregroundColor(.white)
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: 10)
-                                            .stroke(Color.white, lineWidth: 2)
-                                    )
-                            }
-                            .background(Color.accentColor)
-                            .cornerRadius(10)
                         }
                     }
                 }
-                .padding([.top], 5)
-            }
+            }.padding([.top], 5)
         }
         .padding(.all, 4)
         .onTapGesture {
             // TODO: This gives no feedback to the user, and it only works if the text is tapped
             UIPasteboard.general.setValue(notification.formatMessage(), forPasteboardType: UTType.plainText.identifier)
+            store.toggleRead(forNotification: notification)
         }
-        .background(
-            notification.unread ? Color.accentColor : Color.primary
-        )
     }
 }
 

--- a/ntfy/Views/NotificationListView.swift
+++ b/ntfy/Views/NotificationListView.swift
@@ -328,6 +328,9 @@ struct NotificationRowView: View {
             // TODO: This gives no feedback to the user, and it only works if the text is tapped
             UIPasteboard.general.setValue(notification.formatMessage(), forPasteboardType: UTType.plainText.identifier)
         }
+        .background(
+            notification.unread ? Color.accentColor : Color.primary
+        )
     }
 }
 

--- a/ntfy/Views/NotificationListView.swift
+++ b/ntfy/Views/NotificationListView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 enum ActiveAlert {
-    case clear, unsubscribe, selected
+    case clear, unsubscribe, selected, readAll
 }
 
 struct NotificationListView: View {
@@ -149,6 +149,15 @@ struct NotificationListView: View {
                         action: deleteSelected
                     ),
                     secondaryButton: .cancel())
+            case .readAll:
+                return Alert(
+                    title: Text("Mark as read"),
+                    message: Text("Do you really want to mark all of the notifications in this topic as read?"),
+                    primaryButton: .destructive(
+                        Text("Mark as read"),
+                        action: markAsReadAll
+                    ),
+                    secondaryButton: .cancel())
             }
         }
         .overlay(Group {
@@ -230,6 +239,12 @@ struct NotificationListView: View {
             selection = Set<Notification>()
         }
         editMode = .inactive
+    }
+
+    private func markAsReadAll() {
+        DispatchQueue.global(qos: .background).async {
+            store.markAsRead(allNotificationsFor: subscription)
+        }
     }
     
     private func cancelSubscriptionNotifications() {

--- a/ntfy/Views/SubscriptionListView.swift
+++ b/ntfy/Views/SubscriptionListView.swift
@@ -145,6 +145,7 @@ struct SubscriptionItemRowView: View {
     
     var body: some View {
         let totalNotificationCount = subscription.notificationCount()
+        let unreadNotificationCount = subscription.unreadNotificationCount()
         VStack(alignment: .leading, spacing: 0) {
             HStack {
                 Text(subscription.displayName())
@@ -160,7 +161,7 @@ struct SubscriptionItemRowView: View {
                     .foregroundColor(.gray)
             }
             Spacer()
-            Text("\(totalNotificationCount) notification\(totalNotificationCount != 1 ? "s" : "")")
+            Text("\(totalNotificationCount) notification\(totalNotificationCount != 1 ? "s" : ""); \(unreadNotificationCount) unread")
                 .font(.subheadline)
                 .foregroundColor(.gray)
         }

--- a/ntfyNSE/NotificationService.swift
+++ b/ntfyNSE/NotificationService.swift
@@ -62,6 +62,7 @@ class NotificationService: UNNotificationServiceExtension {
             return
         }
         Store.shared.save(notificationFromMessage: message, withSubscription: subscription)
+        content.badge = (store?.totalUnreadNotificationCount ?? 0) as NSNumber
         contentHandler(content)
     }
     


### PR DESCRIPTION
This pull request adds an 'unread' flag to each notification, and a number of UI changes to support this.

In more detail, the Notification entity has been extended to have an 'unread' field (unread == true; read == false).
The user interface has been updated to:
- indicate which notifications are unread (denoted by a blue dot next to the notification)
- give the ability to toggle between read and unread for individual notifications by tapping on the notification
- give the ability to set all notifications for a single subscription to 'read'
- for each subscription, in the subscription list, give the count of unread notifications
- create a badge on the app icon in the user's home screen that depicts the total count of unread notifications across all topics that the user is subscribed to
- All counts, including the icon badge, update automatically as new notifications arrive, as notifications are deleted, or as the user unsubscribes from topics

Screenshots of enhancements:

Subscription list:
![883C659C-33DC-42E0-8213-D5A046E4733E_4_5005_c](https://github.com/user-attachments/assets/31fefd47-1013-4a91-ae56-9c4aad31afcc)

Notification list:
![58B7857B-72B1-4A93-852C-49A6AA0C92F3_4_5005_c](https://github.com/user-attachments/assets/3aecd4fc-3fc1-4bf8-9d62-992d07594173)

About to mark all notifications to 'read':
![09680535-DEA1-4E03-8163-1E1C24F7C06B_4_5005_c](https://github.com/user-attachments/assets/b740d4c7-e3c9-482f-a709-046abbc398ee)

![DB4B5C37-28CE-409E-ADAC-DB9D06DB3C2F_4_5005_c](https://github.com/user-attachments/assets/5cbb7c51-5ae9-4118-9a0f-422ed2a19b3f)

App icon with badge:
![05B65379-15DB-414B-BE51-44DB29A3A93B_4_5005_c](https://github.com/user-attachments/assets/3236bafb-c63c-4737-a9fd-1a9287cf9231)
