### PR TITLE
feat: Allow links in notification messages to be opened

### DIFF
--- a/ntfy/Views/NotificationListView.swift
+++ b/ntfy/Views/NotificationListView.swift
@@ -287,8 +287,13 @@ struct NotificationRowView: View {
                     .bold()
                     .padding([.bottom], 2)
             }
-            Text(notification.formatMessage())
-                .font(.body)
+            if #available(iOS 15.0, *) {
+                Text(makeAttributedText(from: notification.formatMessage()))
+                    .font(.body)
+            } else {
+                Text(notification.formatMessage())
+                    .font(.body)
+            }
             if !notification.nonEmojiTags().isEmpty {
                 Text("Tags: " + notification.nonEmojiTags().joined(separator: ", "))
                     .font(.subheadline)
@@ -328,6 +333,25 @@ struct NotificationRowView: View {
             // TODO: This gives no feedback to the user, and it only works if the text is tapped
             UIPasteboard.general.setValue(notification.formatMessage(), forPasteboardType: UTType.plainText.identifier)
         }
+    }
+
+    @available(iOS 15.0, *)
+    private func makeAttributedText(from text: String) -> AttributedString {
+        var attributedString = AttributedString(text)
+
+        let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+        let range = NSRange(location: 0, length: text.utf16.count)
+
+        detector?.enumerateMatches(in: text, options: [], range: range) { match, _, _ in
+            if let match = match,
+               let url = match.url,
+               let stringRange = Range(match.range, in: text),
+               let attributedRange = attributedString.range(of: String(text[stringRange])) {
+                attributedString[attributedRange].link = url
+            }
+        }
+
+        return attributedString
     }
 }
 


### PR DESCRIPTION
This adds support for detecting URLs in notification messages and rendering them as tappable links (iOS 15+).

Uses NSDataDetector and AttributedString to convert plain text links into interactive links that users can tap to open in a browser. This improves usability when messages include documentation links, external references, or any shared URLs.

Before:  
<img src="https://github.com/user-attachments/assets/cd65e64f-e659-459e-b680-d47eaca4ce06" width="300" />

After:  
<img src="https://github.com/user-attachments/assets/9ba57fc8-93a3-4368-b63c-938375376c05" width="300" />