### PR TITLE
feat: Add Markdown rendering with in-app Safari browser for links

### DIFF
--- a/ntfy.xcodeproj/project.pbxproj
+++ b/ntfy.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		02024E60283D7CBB0064224A /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02024E5F283D7CBB0064224A /* Extensions.swift */; };
+		558C6A752E866FB700F0D84A /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 558C6A742E866FB700F0D84A /* MarkdownUI */; };
 		9407EDDA284ADE1F00C1C334 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9407EDD9284ADE1F00C1C334 /* User.swift */; };
 		9407EDDB284ADE1F00C1C334 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9407EDD9284ADE1F00C1C334 /* User.swift */; };
 		9474F1C1282F2AA700CDE4DD /* AppMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9474F1C0282F2AA700CDE4DD /* AppMain.swift */; };
@@ -123,6 +124,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9474F1D0282F2BB600CDE4DD /* FirebaseMessaging in Frameworks */,
+				558C6A752E866FB700F0D84A /* MarkdownUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -278,6 +280,7 @@
 			name = ntfy;
 			packageProductDependencies = (
 				9474F1CF282F2BB600CDE4DD /* FirebaseMessaging */,
+				558C6A742E866FB700F0D84A /* MarkdownUI */,
 			);
 			productName = ntfy;
 			productReference = 9474F1BD282F2AA700CDE4DD /* ntfy.app */;
@@ -329,6 +332,7 @@
 			mainGroup = 9474F1B4282F2AA700CDE4DD;
 			packageReferences = (
 				9474F1CE282F2BB600CDE4DD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				558C6A732E866FB700F0D84A /* XCRemoteSwiftPackageReference "MarkdownUI" */,
 			);
 			productRefGroup = 9474F1BE282F2AA700CDE4DD /* Products */;
 			projectDirPath = "";
@@ -697,6 +701,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		558C6A732E866FB700F0D84A /* XCRemoteSwiftPackageReference "MarkdownUI" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/gonzalezreal/MarkdownUI";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.4.1;
+			};
+		};
 		9474F1CE282F2BB600CDE4DD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
@@ -708,6 +720,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		558C6A742E866FB700F0D84A /* MarkdownUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 558C6A732E866FB700F0D84A /* XCRemoteSwiftPackageReference "MarkdownUI" */;
+			productName = MarkdownUI;
+		};
 		9474F1CF282F2BB600CDE4DD /* FirebaseMessaging */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 9474F1CE282F2BB600CDE4DD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;

--- a/ntfy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ntfy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "1662d308dac2642be0673136550bd66bf8a64ab6f7a3e7fbd975ad53b5faef70",
   "pins" : [
     {
       "identity" : "abseil-cpp-swiftpm",
@@ -82,12 +83,30 @@
       }
     },
     {
+      "identity" : "markdownui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/MarkdownUI",
+      "state" : {
+        "revision" : "5f613358148239d0292c0cef674a3c2314737f9e",
+        "version" : "2.4.1"
+      }
+    },
+    {
       "identity" : "nanopb",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/nanopb.git",
       "state" : {
         "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
         "version" : "2.30909.0"
+      }
+    },
+    {
+      "identity" : "networkimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/NetworkImage",
+      "state" : {
+        "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
+        "version" : "6.0.1"
       }
     },
     {
@@ -100,6 +119,15 @@
       }
     },
     {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark",
+      "state" : {
+        "revision" : "b97d09472e847a416629f026eceae0e2afcfad65",
+        "version" : "0.7.0"
+      }
+    },
+    {
       "identity" : "swift-protobuf",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
@@ -109,5 +137,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/ntfy.xcodeproj/xcshareddata/xcschemes/ntfyNSE.xcscheme
+++ b/ntfy.xcodeproj/xcshareddata/xcschemes/ntfyNSE.xcscheme
@@ -77,6 +77,7 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
       launchAutomaticallySubstyle = "2">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/ntfy/Views/NotificationListView.swift
+++ b/ntfy/Views/NotificationListView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 import UniformTypeIdentifiers
+import MarkdownUI
+import SafariServices
 
 enum ActiveAlert {
     case clear, unsubscribe, selected
@@ -251,7 +253,9 @@ struct NotificationListView: View {
 struct NotificationRowView: View {
     @EnvironmentObject private var store: Store
     @ObservedObject var notification: Notification
-    
+    @State private var showSafari = false
+    @State private var safariURL: URL?
+
     var body: some View {
         if #available(iOS 15.0, *) {
             notificationRow
@@ -262,8 +266,18 @@ struct NotificationRowView: View {
                         Label("Delete", systemImage: "trash.circle")
                     }
                 }
+                .sheet(isPresented: $showSafari) {
+                    if let url = safariURL {
+                        SafariView(url: url)
+                    }
+                }
         } else {
             notificationRow
+                .sheet(isPresented: $showSafari) {
+                    if let url = safariURL {
+                        SafariView(url: url)
+                    }
+                }
         }
     }
     
@@ -287,8 +301,14 @@ struct NotificationRowView: View {
                     .bold()
                     .padding([.bottom], 2)
             }
-            Text(notification.formatMessage())
-                .font(.body)
+            // Render message as Markdown for clickable links
+            Markdown(notification.formatMessage())
+                .markdownTheme(.gitHub)
+                .environment(\.openURL, OpenURLAction { url in
+                    safariURL = url
+                    showSafari = true
+                    return .handled
+                })
             if !notification.nonEmojiTags().isEmpty {
                 Text("Tags: " + notification.nonEmojiTags().joined(separator: ", "))
                     .font(.subheadline)
@@ -345,5 +365,18 @@ struct NotificationListView_Previews: PreviewProvider {
                 .environmentObject(store)
         }
     }
+}
+
+// Safari View for in-app browsing
+struct SafariView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        let safari = SFSafariViewController(url: url)
+        safari.preferredControlTintColor = .systemBlue
+        return safari
+    }
+
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {}
 }
 


### PR DESCRIPTION
 ## Summary

  Makes URLs in notifications clickable by adding Markdown rendering. Links open in an in-app Safari browser.

  ## Changes

  - Added MarkdownUI library via Swift Package Manager
  - URLs are now clickable
  - Links open in-app (SFSafariViewController) instead of external Safari

  ## Testing

  ```bash
  # Plain URL (auto-linkified)
  curl -d "Check out https://github.com" ntfy.sh/your-topic

  # Markdown formatting
  curl -d "**Bold** text with [clickable link](https://ntfy.sh)" ntfy.sh/your-topic

  Both plain URLs and Markdown links become clickable.

  Notes

  - Non-breaking change (plain text still works)
  - Minimal implementation in NotificationListView.swift

  Fixes the long-standing issue of non-clickable URLs in notifications.