### PR TITLE
fix(ios): fix notification delivery, add Firebase robustness, persist logs, and add tests

### DIFF
--- a/ntfy.xcodeproj/project.pbxproj
+++ b/ntfy.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -55,6 +55,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		4DCC2B852F450D9F0069FE8A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9474F1B5282F2AA700CDE4DD /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9474F1BC282F2AA700CDE4DD;
+			remoteInfo = ntfy;
+		};
 		9474F1E9282F3FFD00CDE4DD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9474F1B5282F2AA700CDE4DD /* Project object */;
@@ -80,6 +87,7 @@
 
 /* Begin PBXFileReference section */
 		02024E5F283D7CBB0064224A /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		4DCC2B812F450D9F0069FE8A /* ntfyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ntfyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9407EDD9284ADE1F00C1C334 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		9474F1BD282F2AA700CDE4DD /* ntfy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ntfy.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9474F1C0282F2AA700CDE4DD /* AppMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMain.swift; sourceTree = "<group>"; };
@@ -117,7 +125,18 @@
 		E27008112AF1030A006E33BA /* NotificationsObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsObservable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		4DCC2B822F450D9F0069FE8A /* ntfyTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ntfyTests; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
+		4DCC2B7E2F450D9F0069FE8A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9474F1BA282F2AA700CDE4DD /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -141,6 +160,7 @@
 			children = (
 				9474F1BF282F2AA700CDE4DD /* ntfy */,
 				9474F1E5282F3FFD00CDE4DD /* ntfyNSE */,
+				4DCC2B822F450D9F0069FE8A /* ntfyTests */,
 				9474F1BE282F2AA700CDE4DD /* Products */,
 				9474F1DD282F3A2E00CDE4DD /* Frameworks */,
 			);
@@ -151,6 +171,7 @@
 			children = (
 				9474F1BD282F2AA700CDE4DD /* ntfy.app */,
 				9474F1E4282F3FFD00CDE4DD /* ntfyNSE.appex */,
+				4DCC2B812F450D9F0069FE8A /* ntfyTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -261,6 +282,29 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		4DCC2B802F450D9F0069FE8A /* ntfyTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4DCC2B892F450D9F0069FE8A /* Build configuration list for PBXNativeTarget "ntfyTests" */;
+			buildPhases = (
+				4DCC2B7D2F450D9F0069FE8A /* Sources */,
+				4DCC2B7E2F450D9F0069FE8A /* Frameworks */,
+				4DCC2B7F2F450D9F0069FE8A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4DCC2B862F450D9F0069FE8A /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				4DCC2B822F450D9F0069FE8A /* ntfyTests */,
+			);
+			name = ntfyTests;
+			packageProductDependencies = (
+			);
+			productName = ntfyTests;
+			productReference = 4DCC2B812F450D9F0069FE8A /* ntfyTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		9474F1BC282F2AA700CDE4DD /* ntfy */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9474F1CB282F2AA800CDE4DD /* Build configuration list for PBXNativeTarget "ntfy" */;
@@ -307,9 +351,13 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1330;
+				LastSwiftUpdateCheck = 2620;
 				LastUpgradeCheck = 1330;
 				TargetAttributes = {
+					4DCC2B802F450D9F0069FE8A = {
+						CreatedOnToolsVersion = 26.2;
+						TestTargetID = 9474F1BC282F2AA700CDE4DD;
+					};
 					9474F1BC282F2AA700CDE4DD = {
 						CreatedOnToolsVersion = 13.3.1;
 					};
@@ -336,11 +384,19 @@
 			targets = (
 				9474F1BC282F2AA700CDE4DD /* ntfy */,
 				9474F1E3282F3FFD00CDE4DD /* ntfyNSE */,
+				4DCC2B802F450D9F0069FE8A /* ntfyTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		4DCC2B7F2F450D9F0069FE8A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9474F1BB282F2AA700CDE4DD /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -363,6 +419,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		4DCC2B7D2F450D9F0069FE8A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9474F1B9282F2AA700CDE4DD /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -418,6 +481,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		4DCC2B862F450D9F0069FE8A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9474F1BC282F2AA700CDE4DD /* ntfy */;
+			targetProxy = 4DCC2B852F450D9F0069FE8A /* PBXContainerItemProxy */;
+		};
 		9474F1EA282F3FFD00CDE4DD /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 9474F1E3282F3FFD00CDE4DD /* ntfyNSE */;
@@ -426,6 +494,61 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		4DCC2B872F450D9F0069FE8A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = D2Z26AS3NJ;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = personal.ntfyTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ntfy.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ntfy";
+			};
+			name = Debug;
+		};
+		4DCC2B882F450D9F0069FE8A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = D2Z26AS3NJ;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = personal.ntfyTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ntfy.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ntfy";
+			};
+			name = Release;
+		};
 		9474F1C9282F2AA800CDE4DD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -667,6 +790,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		4DCC2B892F450D9F0069FE8A /* Build configuration list for PBXNativeTarget "ntfyTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4DCC2B872F450D9F0069FE8A /* Debug */,
+				4DCC2B882F450D9F0069FE8A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		9474F1B8282F2AA700CDE4DD /* Build configuration list for PBXProject "ntfy" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/ntfy.xcodeproj/xcshareddata/xcschemes/ntfy.xcscheme
+++ b/ntfy.xcodeproj/xcshareddata/xcschemes/ntfy.xcscheme
@@ -26,21 +26,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
-      <Testables>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4DCC2B802F450D9F0069FE8A"
-               BuildableName = "ntfyTests.xctest"
-               BlueprintName = "ntfyTests"
-               ReferencedContainer = "container:ntfy.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:ntfy.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/ntfy.xcodeproj/xcshareddata/xcschemes/ntfy.xcscheme
+++ b/ntfy.xcodeproj/xcshareddata/xcschemes/ntfy.xcscheme
@@ -28,6 +28,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4DCC2B802F450D9F0069FE8A"
+               BuildableName = "ntfyTests.xctest"
+               BlueprintName = "ntfyTests"
+               ReferencedContainer = "container:ntfy.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/ntfy.xcodeproj/xcshareddata/xcschemes/ntfyNSE.xcscheme
+++ b/ntfy.xcodeproj/xcshareddata/xcschemes/ntfyNSE.xcscheme
@@ -43,6 +43,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4DCC2B802F450D9F0069FE8A"
+               BuildableName = "ntfyTests.xctest"
+               BlueprintName = "ntfyTests"
+               ReferencedContainer = "container:ntfy.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/ntfy.xctestplan
+++ b/ntfy.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "77B014CB-79DC-4AEF-8A0A-1C7CA5979C9B",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "parallelizationEnabled" : false
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:ntfy.xcodeproj",
+        "identifier" : "4DCC2B802F450D9F0069FE8A",
+        "name" : "ntfyTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/ntfy/App/AppDelegate.swift
+++ b/ntfy/App/AppDelegate.swift
@@ -160,20 +160,33 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 extension AppDelegate: MessagingDelegate {
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         Log.d(tag, "Firebase token received: \(String(describing: fcmToken))")
-        
-        // Subscribe to ~poll topic
-        Messaging.messaging().subscribe(toTopic: pollTopic)
-        
-        // Re-subscribe to Firebase for all topics
+        subscribeToFirebaseTopics()
+    }
+}
+
+extension AppDelegate {
+    /// Subscribes (or re-subscribes) to all Firebase topics for the current subscriptions.
+    /// Safe to call repeatedly — Firebase no-ops if already subscribed, but will retry
+    /// a previous failed subscription. Called on token refresh and on every app foreground
+    /// to recover from silent subscription failures (see #1305).
+    func subscribeToFirebaseTopics() {
+        subscribeToTopic(pollTopic)
         let store = Store.shared
-        store.getSubscriptions()?.forEach{ subscription in
-            if let baseUrl = subscription.baseUrl, let topic = subscription.topic {
-                Log.d(tag, "Re-subscribing to topic \(baseUrl)/\(topic)")
-                if baseUrl == Config.appBaseUrl {
-                    Messaging.messaging().subscribe(toTopic: topic)
-                } else {
-                    Messaging.messaging().subscribe(toTopic: topicHash(baseUrl: baseUrl, topic: topic))
-                }
+        store.getSubscriptions()?.forEach { subscription in
+            guard let baseUrl = subscription.baseUrl, let topic = subscription.topic else { return }
+            if baseUrl == Config.appBaseUrl {
+                subscribeToTopic(topic)
+            } else {
+                subscribeToTopic(topicHash(baseUrl: baseUrl, topic: topic))
+            }
+        }
+    }
+
+    private func subscribeToTopic(_ topic: String) {
+        Log.d(tag, "Subscribing to Firebase topic: \(topic)")
+        Messaging.messaging().subscribe(toTopic: topic) { error in
+            if let error = error {
+                Log.e(self.tag, "Failed to subscribe to Firebase topic \(topic)", error)
             }
         }
     }

--- a/ntfy/App/AppDelegate.swift
+++ b/ntfy/App/AppDelegate.swift
@@ -52,6 +52,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ObservableObject {
         // Poll and show new messages as notifications
         // Fix: use DispatchGroup so completionHandler is called AFTER all polls complete
         let store = Store.shared
+        // Fix: refresh context so lastNotificationId reflects any recent NSE writes
+        // before we build the poll URL (since=<lastNotificationId>). Without this,
+        // the main app context can be stale and poll for already-delivered messages.
+        store.hardRefresh()
         let subscriptionManager = SubscriptionManager(store: store)
         let subscriptions = store.getSubscriptions() ?? []
         let group = DispatchGroup()

--- a/ntfy/App/AppDelegate.swift
+++ b/ntfy/App/AppDelegate.swift
@@ -17,7 +17,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ObservableObject {
         Log.d(tag, "Launching AppDelegate")
 
         FirebaseApp.configure()
-        FirebaseConfiguration.shared.setLoggerLevel(.max)
+        FirebaseConfiguration.shared.setLoggerLevel(.warning)
 
         // Register app permissions for push notifications
         UNUserNotificationCenter.current().delegate = self
@@ -50,16 +50,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ObservableObject {
         }
 
         // Poll and show new messages as notifications
+        // Fix: use DispatchGroup so completionHandler is called AFTER all polls complete
         let store = Store.shared
         let subscriptionManager = SubscriptionManager(store: store)
-        store.getSubscriptions()?.forEach { subscription in
+        let subscriptions = store.getSubscriptions() ?? []
+        let group = DispatchGroup()
+        var hasNewData = false
+        subscriptions.forEach { subscription in
+            group.enter()
             subscriptionManager.poll(subscription) { messages in
-                messages.forEach { message in
-                    self.showNotification(subscription, message)
+                if !messages.isEmpty {
+                    hasNewData = true
+                    messages.forEach { message in
+                        self.showNotification(subscription, message)
+                    }
                 }
+                group.leave()
             }
         }
-        completionHandler(.newData)
+        group.notify(queue: .main) {
+            completionHandler(hasNewData ? .newData : .noData)
+        }
     }
     
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
@@ -89,7 +100,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ObservableObject {
 }
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
-    /// Executed when the app is in the foreground. Nothing has to be done here, except call the completionHandler.
+    /// Executed when the app is in the foreground.
+    /// Fix: save the notification to CoreData as a fallback (NSE doesn't run on simulator
+    /// or when the app is in the foreground and NSE is skipped).
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
@@ -97,6 +110,13 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     ) {
         let userInfo = notification.request.content.userInfo
         Log.d(tag, "Notification received via userNotificationCenter(willPresent)", userInfo)
+        if let message = Message.from(userInfo: userInfo), message.event == "message" {
+            let store = Store.shared
+            let baseUrl = userInfo["base_url"] as? String ?? Config.appBaseUrl
+            if let subscription = store.getSubscription(baseUrl: baseUrl, topic: message.topic) {
+                store.save(notificationFromMessage: message, withSubscription: subscription)
+            }
+        }
         completionHandler([[.banner, .sound]])
     }
     

--- a/ntfy/App/AppDelegate.swift
+++ b/ntfy/App/AppDelegate.swift
@@ -174,16 +174,10 @@ extension AppDelegate {
     /// a previous failed subscription. Called on token refresh and on every app foreground
     /// to recover from silent subscription failures (see #1305).
     func subscribeToFirebaseTopics() {
-        subscribeToTopic(pollTopic)
         let store = Store.shared
-        store.getSubscriptions()?.forEach { subscription in
-            guard let baseUrl = subscription.baseUrl, let topic = subscription.topic else { return }
-            if baseUrl == Config.appBaseUrl {
-                subscribeToTopic(topic)
-            } else {
-                subscribeToTopic(topicHash(baseUrl: baseUrl, topic: topic))
-            }
-        }
+        let subscriptions = store.getSubscriptions() ?? []
+        firebaseTopics(subscriptions: subscriptions, appBaseUrl: Config.appBaseUrl, pollTopic: pollTopic)
+            .forEach { subscribeToTopic($0) }
     }
 
     private func subscribeToTopic(_ topic: String) {
@@ -194,4 +188,21 @@ extension AppDelegate {
             }
         }
     }
+}
+
+/// Returns the Firebase topic names for the given subscriptions.
+/// ~poll is always included. ntfy.sh (appBaseUrl) topics use the plain topic name;
+/// self-hosted topics use SHA256(baseUrl/topic) to avoid leaking server addresses.
+/// Package-internal for testability without requiring AppDelegate instantiation.
+func firebaseTopics(subscriptions: [Subscription], appBaseUrl: String, pollTopic: String) -> [String] {
+    var topics = [pollTopic]
+    subscriptions.forEach { subscription in
+        guard let baseUrl = subscription.baseUrl, let topic = subscription.topic else { return }
+        if baseUrl == appBaseUrl {
+            topics.append(topic)
+        } else {
+            topics.append(topicHash(baseUrl: baseUrl, topic: topic))
+        }
+    }
+    return topics
 }

--- a/ntfy/App/AppDelegate.swift
+++ b/ntfy/App/AppDelegate.swift
@@ -49,6 +49,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ObservableObject {
             return
         }
 
+        // Re-subscribe to Firebase topics in the background to recover from silent
+        // subscription failures without waiting for the user to open the app (#1305).
+        subscribeToFirebaseTopics()
+
         // Poll and show new messages as notifications
         // Fix: use DispatchGroup so completionHandler is called AFTER all polls complete
         let store = Store.shared

--- a/ntfy/App/AppMain.swift
+++ b/ntfy/App/AppMain.swift
@@ -24,9 +24,14 @@ struct AppMain: App {
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
                     // Use this hook instead of applicationDidBecomeActive, see https://stackoverflow.com/a/68888509/1440785
                     // That post also explains how to start SwiftUI from AppDelegate if that's ever needed.
-                    
+
                     Log.d(tag, "App became active, refreshing objects")
                     store.hardRefresh()
+
+                    // Re-subscribe to Firebase topics on every foreground to recover from
+                    // silent subscription failures (token rotation race, network loss, etc.).
+                    // Firebase no-ops if already subscribed; this only retries failed ones (#1305).
+                    delegate.subscribeToFirebaseTopics()
                 }
         }
     }

--- a/ntfy/Persistence/Store.swift
+++ b/ntfy/Persistence/Store.swift
@@ -18,11 +18,21 @@ class Store: ObservableObject {
     private var cancellables: Set<AnyCancellable> = []
 
     init(inMemory: Bool = false) {
-        let storeUrl = (inMemory) ? URL(fileURLWithPath: "/dev/null") : FileManager.default
-            .containerURL(forSecurityApplicationGroupIdentifier: Store.appGroup)!
-            .appendingPathComponent("ntfy.sqlite")
-        let description = NSPersistentStoreDescription(url: storeUrl)
-        description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+        let description: NSPersistentStoreDescription
+        if inMemory {
+            // NSInMemoryStoreType gives each Store instance its own isolated database,
+            // which is required for test isolation. Using /dev/null (SQLite) caused all
+            // in-memory instances to share the same backing store within a process.
+            description = NSPersistentStoreDescription()
+            description.type = NSInMemoryStoreType
+        } else {
+            let storeUrl = FileManager.default
+                .containerURL(forSecurityApplicationGroupIdentifier: Store.appGroup)!
+                .appendingPathComponent("ntfy.sqlite")
+            description = NSPersistentStoreDescription(url: storeUrl)
+            // Required for NSE → main app change propagation (SQLite only)
+            description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+        }
 
         // Set up container and observe changes from app extension
         container = NSPersistentContainer(name: Store.modelName)
@@ -108,6 +118,19 @@ class Store: ObservableObject {
     // MARK: Notifications
     
     func save(notificationFromMessage message: Message, withSubscription subscription: Subscription) {
+        // Idempotent: skip if a notification with this ID is already stored.
+        // Guards against races between NSE, willPresent, and background poll all
+        // delivering the same message through different paths.
+        // Note: CoreData's mergeByPropertyStoreTrumpMergePolicyType also prevents DB duplicates,
+        // but this explicit check avoids an unnecessary insert + merge cycle and is clearer in intent.
+        let messageId = message.id
+        let existing = Notification.fetchRequest()
+        existing.predicate = NSPredicate(format: "id = %@", messageId)
+        existing.fetchLimit = 1
+        if (try? context.fetch(existing).isEmpty) == false {
+            Log.d(Store.tag, "Notification \(messageId) already stored, skipping duplicate save")
+            return
+        }
         do {
             let notification = Notification(context: context)
             notification.id = message.id

--- a/ntfy/Persistence/Store.swift
+++ b/ntfy/Persistence/Store.swift
@@ -25,13 +25,19 @@ class Store: ObservableObject {
             // in-memory instances to share the same backing store within a process.
             description = NSPersistentStoreDescription()
             description.type = NSInMemoryStoreType
-        } else {
-            let storeUrl = FileManager.default
-                .containerURL(forSecurityApplicationGroupIdentifier: Store.appGroup)!
-                .appendingPathComponent("ntfy.sqlite")
+        } else if let containerUrl = FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: Store.appGroup) {
+            let storeUrl = containerUrl.appendingPathComponent("ntfy.sqlite")
             description = NSPersistentStoreDescription(url: storeUrl)
             // Required for NSE → main app change propagation (SQLite only)
             description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+        } else {
+            // App group unavailable (e.g. unsigned build, unit test host).
+            // Fall back to in-memory so the app starts rather than crashing.
+            // Data will not persist across launches in this state.
+            Log.e(Store.tag, "App group \(Store.appGroup) unavailable, falling back to in-memory store")
+            description = NSPersistentStoreDescription()
+            description.type = NSInMemoryStoreType
         }
 
         // Set up container and observe changes from app extension

--- a/ntfy/Utils/Log.swift
+++ b/ntfy/Utils/Log.swift
@@ -9,38 +9,95 @@ struct Log {
         formatter.timeZone = .current
         return formatter
     }()
-    
+
+    // Persistent log file in the shared App Group container so both the main app
+    // and the Notification Service Extension write to the same file. The file is
+    // capped at ~512 KB; when exceeded the oldest half is discarded so recent
+    // entries (NSE triggers, APNs/FCM token events) are always preserved.
+    private static let appGroup = "group.io.heckel.ntfy"
+    private static let maxLogFileSize = 512 * 1024  // 512 KB
+    private static let fileQueue = DispatchQueue(label: "io.heckel.ntfy.log", qos: .background)
+
+    static var logFileUrl: URL? {
+        FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: appGroup)?
+            .appendingPathComponent("ntfy.log")
+    }
+
     static func d(_ tag: String, _ message: String, _ other: Any?...) {
         log(.debug, tag, message, other)
     }
-    
+
     static func i(_ tag: String, _ message: String, _ other: Any?...) {
         log(.info, tag, message, other)
     }
-    
+
     static func w(_ tag: String, _ message: String, _ other: Any?...) {
         log(.warning, tag, message, other)
     }
-    
+
     static func e(_ tag: String, _ message: String, _ other: Any?...) {
         log(.error, tag, message, other)
     }
-    
+
+    /// Returns the full contents of the persisted log file, or an empty string if unavailable.
+    static func readAll() -> String {
+        guard let url = logFileUrl,
+              let data = try? Data(contentsOf: url),
+              let content = String(data: data, encoding: .utf8) else {
+            return ""
+        }
+        return content
+    }
+
     private static func log(_ level: LogLevel, _ tag: String, _ message: String, _ other: Any?...) {
-        print("\(dateStr()) ntfyApp [\(levelStr(level))] \(tag): \(message)")
+        let line = "\(dateStr()) ntfyApp [\(levelStr(level))] \(tag): \(message)"
+        print(line)
+        var extra = ""
         if !other.isEmpty {
             other.forEach { o in
                 if let o = o {
                     print("  ", o)
+                    extra += "\n  \(o)"
                 }
             }
         }
+        appendToFile(line + extra)
     }
-    
+
+    private static func appendToFile(_ line: String) {
+        guard let url = logFileUrl else { return }
+        fileQueue.async {
+            let entry = line + "\n"
+            guard let data = entry.data(using: .utf8) else { return }
+            if let fileHandle = try? FileHandle(forWritingTo: url) {
+                defer { fileHandle.closeFile() }
+                fileHandle.seekToEndOfFile()
+                fileHandle.write(data)
+                rotateIfNeeded(url: url)
+            } else {
+                // First write: create the file
+                try? data.write(to: url, options: .atomic)
+            }
+        }
+    }
+
+    // Keeps the newest half of the file when the size limit is reached, so
+    // the log never grows unbounded while always retaining the most recent entries.
+    private static func rotateIfNeeded(url: URL) {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let size = attrs[.size] as? Int, size > maxLogFileSize,
+              let data = try? Data(contentsOf: url),
+              let content = String(data: data, encoding: .utf8) else { return }
+        let lines = content.components(separatedBy: "\n")
+        let trimmed = lines.dropFirst(lines.count / 2).joined(separator: "\n")
+        try? trimmed.write(to: url, atomically: true, encoding: .utf8)
+    }
+
     private static func dateStr() -> String {
         dateFormatter.string(from: Date())
     }
-    
+
     private static func levelStr(_ level: LogLevel) -> String {
         switch level {
         case .debug: return "DEBUG"

--- a/ntfy/Views/SettingsView.swift
+++ b/ntfy/Views/SettingsView.swift
@@ -298,6 +298,9 @@ struct UserRowView: View {
 }
 
 struct AboutView: View {
+    @State private var showShareSheet = false
+    @State private var logContent = ""
+
     var body: some View {
         Group {
             Button(action: {
@@ -333,6 +336,21 @@ struct AboutView: View {
                     Image(systemName: "star.fill")
                 }
             }
+            Button(action: {
+                let logs = Log.readAll()
+                let header = "ntfy \(Config.version) (\(Config.build)) — iOS \(Config.osVersion)\n\n"
+                logContent = logs.isEmpty ? header + "(no logs captured yet)" : header + logs
+                showShareSheet = true
+            }) {
+                HStack {
+                    Text("Share logs")
+                    Spacer()
+                    Image(systemName: "square.and.arrow.up")
+                }
+            }
+            .sheet(isPresented: $showShareSheet) {
+                ActivityViewController(items: [logContent])
+            }
             HStack {
                 Text("Version")
                 Spacer()
@@ -342,11 +360,22 @@ struct AboutView: View {
         }
         .foregroundColor(.primary)
     }
-    
+
     private func open(url: String) {
         guard let url = URL(string: url) else { return }
         UIApplication.shared.open(url, options: [:], completionHandler: nil)
     }
+}
+
+/// Thin SwiftUI wrapper around UIActivityViewController for sharing arbitrary items.
+struct ActivityViewController: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
 }
 
 struct SettingsView_Previews: PreviewProvider {

--- a/ntfyTests/NotificationDeliveryTests.swift
+++ b/ntfyTests/NotificationDeliveryTests.swift
@@ -66,6 +66,53 @@ struct NotificationDeliveryTests {
                 "Should return nil when the message field is missing")
     }
 
+    // MARK: - Idempotent save (polling deduplication)
+
+    /// Contract test: saving the same message ID multiple times (e.g. NSE then background poll)
+    /// must produce exactly one notification in CoreData.
+    ///
+    /// Implementation note: CoreData's mergeByPropertyStoreTrumpMergePolicyType also prevents
+    /// DB duplicates via the uniquenessConstraint on Notification.id. The explicit idempotency
+    /// check in Store.save() makes the intent clear and avoids an unnecessary insert + merge cycle.
+    @Test func savingDuplicateIdIsIdempotent() {
+        let store = Store(inMemory: true)
+        let subscription = store.saveSubscription(baseUrl: "https://ntfy.sh", topic: "topic-idem")
+
+        let message = Message(
+            id: "idem-001",
+            time: 1739661010,
+            event: "message",
+            topic: "topic-idem",
+            message: "Only one copy should exist"
+        )
+
+        store.save(notificationFromMessage: message, withSubscription: subscription) // NSE path
+        store.save(notificationFromMessage: message, withSubscription: subscription) // background poll path
+        store.save(notificationFromMessage: message, withSubscription: subscription) // willPresent path
+
+        store.context.refreshAllObjects()
+        #expect(subscription.notificationCount() == 1,
+                "Three saves with the same ID must produce exactly one notification")
+    }
+
+    /// Two distinct message IDs must both be saved — idempotency must not over-deduplicate.
+    @Test func savingDistinctIdsPreservesBoth() {
+        let store = Store(inMemory: true)
+        let subscription = store.saveSubscription(baseUrl: "https://ntfy.sh", topic: "topic-distinct")
+
+        let first = Message(id: "distinct-001", time: 1739661011, event: "message",
+                            topic: "topic-distinct", message: "First")
+        let second = Message(id: "distinct-002", time: 1739661012, event: "message",
+                             topic: "topic-distinct", message: "Second")
+
+        store.save(notificationFromMessage: first, withSubscription: subscription)
+        store.save(notificationFromMessage: second, withSubscription: subscription)
+
+        store.context.refreshAllObjects()
+        #expect(subscription.notificationCount() == 2,
+                "Two distinct message IDs must each produce a separate notification")
+    }
+
     // MARK: - willPresent save logic
 
     /// Simulates willPresent receiving a foreground push for a subscribed topic.

--- a/ntfyTests/NotificationDeliveryTests.swift
+++ b/ntfyTests/NotificationDeliveryTests.swift
@@ -1,0 +1,187 @@
+import Testing
+import CoreData
+@testable import ntfy
+
+/// Tests for notification delivery fixes.
+///
+/// Background: when a push arrives while the app is in the foreground, iOS calls
+/// userNotificationCenter(_:willPresent:). The upstream only showed a banner and
+/// never saved the message to CoreData, so it never appeared in the topic list (issue #337).
+///
+/// These tests verify the fix and the Message parsing contract that the fix depends on.
+///
+/// Note: tests are serialized because Store(inMemory: true) uses /dev/null as the SQLite URL
+/// and parallel test processes can interfere with each other.
+@Suite(.serialized)
+struct NotificationDeliveryTests {
+
+    // MARK: - Message.from(userInfo:) parsing
+
+    /// The real ntfy server sends `time` and `priority` as strings.
+    /// Parsing must succeed and produce correct field values.
+    @Test func messageFromUserInfoParsesStringTypes() {
+        let userInfo: [AnyHashable: Any] = [
+            "id": "abc123",
+            "time": "1739661000",    // string — as sent by the real server
+            "event": "message",
+            "topic": "topic-parse-string",
+            "message": "Hello from ntfy",
+            "priority": "3",         // string — as sent by the real server
+            "base_url": "https://ntfy.sh"
+        ]
+        let message = Message.from(userInfo: userInfo)
+        #expect(message != nil, "Message.from should succeed when time and priority are strings")
+        #expect(message?.id == "abc123")
+        #expect(message?.time == 1739661000)
+        #expect(message?.event == "message")
+        #expect(message?.topic == "topic-parse-string")
+        #expect(message?.message == "Hello from ntfy")
+        #expect(message?.priority == 3)
+    }
+
+    /// If `time` arrives as a JSON integer (e.g. hand-crafted payload), parsing returns nil.
+    /// This documents the required payload format: all numeric fields must be strings.
+    @Test func messageFromUserInfoFailsWithIntegerTime() {
+        let userInfo: [AnyHashable: Any] = [
+            "id": "abc456",
+            "time": 1739661000,     // integer — wrong format, parser expects String
+            "event": "message",
+            "topic": "topic-parse-int",
+            "message": "Hello from ntfy"
+        ]
+        #expect(Message.from(userInfo: userInfo) == nil,
+                "Message.from must return nil when time is an integer (use string instead)")
+    }
+
+    /// Missing required fields must return nil.
+    @Test func messageFromUserInfoFailsOnMissingMessage() {
+        let userInfo: [AnyHashable: Any] = [
+            "id": "abc789",
+            "time": "1739661000",
+            "event": "message",
+            "topic": "topic-parse-missing"
+            // "message" is intentionally missing
+        ]
+        #expect(Message.from(userInfo: userInfo) == nil,
+                "Should return nil when the message field is missing")
+    }
+
+    // MARK: - willPresent save logic
+
+    /// Simulates willPresent receiving a foreground push for a subscribed topic.
+    /// The notification must be written to CoreData so it appears in the list.
+    @Test func willPresentLogicSavesNotificationForKnownSubscription() {
+        let store = Store(inMemory: true)
+        let subscription = store.saveSubscription(baseUrl: "https://ntfy.sh", topic: "topic-save-known")
+
+        let userInfo: [AnyHashable: Any] = [
+            "id": "save-001",
+            "time": "1739661001",
+            "event": "message",
+            "topic": "topic-save-known",
+            "message": "Fix test: notification should appear in list",
+            "priority": "3",
+            "base_url": "https://ntfy.sh"
+        ]
+
+        // Replicate willPresent fix logic
+        if let message = Message.from(userInfo: userInfo), message.event == "message" {
+            let baseUrl = userInfo["base_url"] as? String ?? Config.appBaseUrl
+            if let sub = store.getSubscription(baseUrl: baseUrl, topic: message.topic) {
+                store.save(notificationFromMessage: message, withSubscription: sub)
+            }
+        }
+
+        store.context.refreshAllObjects()
+        #expect(subscription.notificationCount() == 1,
+                "Notification should be saved to CoreData by the willPresent fix")
+    }
+
+    /// willPresent receives a push for a topic that is NOT subscribed — nothing should be saved.
+    @Test func willPresentLogicSkipsUnknownTopic() {
+        let store = Store(inMemory: true)
+        // No subscriptions
+
+        let userInfo: [AnyHashable: Any] = [
+            "id": "skip-001",
+            "time": "1739661002",
+            "event": "message",
+            "topic": "topic-skip-unknown",
+            "message": "This should not be saved",
+            "base_url": "https://ntfy.sh"
+        ]
+
+        if let message = Message.from(userInfo: userInfo), message.event == "message" {
+            let baseUrl = userInfo["base_url"] as? String ?? Config.appBaseUrl
+            if let sub = store.getSubscription(baseUrl: baseUrl, topic: message.topic) {
+                store.save(notificationFromMessage: message, withSubscription: sub)
+            }
+        }
+
+        #expect(store.getSubscription(baseUrl: "https://ntfy.sh", topic: "topic-skip-unknown") == nil,
+                "No subscription should exist for an unknown topic")
+    }
+
+    /// willPresent must not save keepalive or open events — only "message" events.
+    @Test func willPresentLogicSkipsNonMessageEvents() {
+        let store = Store(inMemory: true)
+        let subscription = store.saveSubscription(baseUrl: "https://ntfy.sh", topic: "topic-keepalive")
+
+        let userInfo: [AnyHashable: Any] = [
+            "id": "keepalive-001",
+            "time": "1739661003",
+            "event": "keepalive",
+            "topic": "topic-keepalive",
+            "message": "",
+            "base_url": "https://ntfy.sh"
+        ]
+
+        if let message = Message.from(userInfo: userInfo), message.event == "message" {
+            let baseUrl = userInfo["base_url"] as? String ?? Config.appBaseUrl
+            if let sub = store.getSubscription(baseUrl: baseUrl, topic: message.topic) {
+                store.save(notificationFromMessage: message, withSubscription: sub)
+            }
+        }
+
+        store.context.refreshAllObjects()
+        #expect(subscription.notificationCount() == 0, "Keepalive events must not be saved")
+    }
+
+    /// If the NSE already saved the notification before willPresent runs,
+    /// a second save with the same ID must not create a duplicate.
+    @Test func willPresentDoesNotDuplicateExistingNotification() {
+        let store = Store(inMemory: true)
+        let subscription = store.saveSubscription(baseUrl: "https://ntfy.sh", topic: "topic-dedup")
+
+        let first = Message(
+            id: "dedup-001",
+            time: 1739661004,
+            event: "message",
+            topic: "topic-dedup",
+            message: "Already saved by NSE"
+        )
+
+        // First save — simulates NSE
+        store.save(notificationFromMessage: first, withSubscription: subscription)
+
+        // Second save — simulates willPresent with same ID
+        let userInfo: [AnyHashable: Any] = [
+            "id": "dedup-001",
+            "time": "1739661004",
+            "event": "message",
+            "topic": "topic-dedup",
+            "message": "Already saved by NSE",
+            "base_url": "https://ntfy.sh"
+        ]
+        if let parsed = Message.from(userInfo: userInfo), parsed.event == "message" {
+            let baseUrl = userInfo["base_url"] as? String ?? Config.appBaseUrl
+            if let sub = store.getSubscription(baseUrl: baseUrl, topic: parsed.topic) {
+                store.save(notificationFromMessage: parsed, withSubscription: sub)
+            }
+        }
+
+        store.context.refreshAllObjects()
+        #expect(subscription.notificationCount() == 1,
+                "Saving the same notification ID twice must not create a duplicate")
+    }
+}

--- a/ntfyTests/NotificationDeliveryTests.swift
+++ b/ntfyTests/NotificationDeliveryTests.swift
@@ -232,3 +232,76 @@ struct NotificationDeliveryTests {
                 "Saving the same notification ID twice must not create a duplicate")
     }
 }
+
+// MARK: - Firebase topic subscription
+
+/// Tests for AppDelegate.firebaseTopics(for:) — the logic that maps subscriptions to
+/// Firebase topic names. The ~poll topic must always be included; ntfy.sh subscriptions
+/// use the plain topic name; self-hosted subscriptions use a SHA256 hash of the URL
+/// so the server address is not leaked to Firebase (#1305).
+@Suite(.serialized)
+struct FirebaseTopicsTests {
+    // Hardcoded to avoid depending on Config.appBaseUrl (Bundle.main.infoDictionary) in tests.
+    private let ntfyBaseUrl = "https://ntfy.sh"
+    private let selfHostedBaseUrl = "https://ntfy.example.com"
+    private let poll = "~poll"
+
+    private func topics(_ subscriptions: [Subscription]) -> [String] {
+        firebaseTopics(subscriptions: subscriptions, appBaseUrl: ntfyBaseUrl, pollTopic: poll)
+    }
+
+    /// No subscriptions — only ~poll must be returned.
+    @Test func emptySubscriptionsReturnsPollOnly() {
+        #expect(topics([]) == [poll],
+                "~poll must always be included even with no subscriptions")
+    }
+
+    /// ntfy.sh subscription — topic name is used directly, not hashed.
+    @Test func ntfyShSubscriptionUsesPlainTopicName() {
+        let store = Store(inMemory: true)
+        let sub = store.saveSubscription(baseUrl: ntfyBaseUrl, topic: "alerts")
+        let result = topics([sub])
+        #expect(result.contains(poll))
+        #expect(result.contains("alerts"),
+                "ntfy.sh topics must appear as plain names in Firebase")
+        #expect(result.count == 2)
+    }
+
+    /// Self-hosted subscription — topic must be hashed to avoid leaking the server URL.
+    @Test func selfHostedSubscriptionUsesTopicHash() {
+        let store = Store(inMemory: true)
+        let sub = store.saveSubscription(baseUrl: selfHostedBaseUrl, topic: "alerts")
+        let expectedHash = topicHash(baseUrl: selfHostedBaseUrl, topic: "alerts")
+        let result = topics([sub])
+        #expect(result.contains(poll))
+        #expect(result.contains(expectedHash),
+                "Self-hosted topics must use SHA256(baseUrl/topic) in Firebase")
+        #expect(!result.contains("alerts"),
+                "Self-hosted topic plain name must not appear in Firebase")
+        #expect(result.count == 2)
+    }
+
+    /// Mixed subscriptions — both plain and hashed topics must appear alongside ~poll.
+    @Test func mixedSubscriptionsProducesCorrectTopics() {
+        let store = Store(inMemory: true)
+        let ntfySub = store.saveSubscription(baseUrl: ntfyBaseUrl, topic: "news")
+        let selfSub = store.saveSubscription(baseUrl: selfHostedBaseUrl, topic: "private")
+        let expectedHash = topicHash(baseUrl: selfHostedBaseUrl, topic: "private")
+        let result = topics([ntfySub, selfSub])
+        #expect(result.contains(poll))
+        #expect(result.contains("news"))
+        #expect(result.contains(expectedHash))
+        #expect(result.count == 3)
+    }
+
+    /// Two self-hosted subscriptions on different servers must produce different hashes.
+    @Test func differentServersProduceDifferentHashes() {
+        let store = Store(inMemory: true)
+        let sub1 = store.saveSubscription(baseUrl: "https://ntfy.server1.com", topic: "topic")
+        let sub2 = store.saveSubscription(baseUrl: "https://ntfy.server2.com", topic: "topic")
+        let result = topics([sub1, sub2])
+        let hashes = result.filter { $0 != poll }
+        #expect(Set(hashes).count == 2,
+                "Different self-hosted servers with the same topic must produce different hashes")
+    }
+}

--- a/ntfyTests/NotificationDeliveryTests.swift
+++ b/ntfyTests/NotificationDeliveryTests.swift
@@ -2,6 +2,18 @@ import Testing
 import CoreData
 @testable import ntfy
 
+/// Top-level serialization wrapper.
+///
+/// Both inner suites create Store(inMemory: true), which initialises an
+/// NSPersistentContainer. Concurrent initialisation of multiple containers
+/// in the same process causes CoreData to emit "Failed to find a unique match
+/// for NSEntityDescription" warnings that can silently break relationship
+/// queries (e.g. subscription.notificationCount()). Wrapping both suites in a
+/// single .serialized parent prevents them from running concurrently regardless
+/// of how the test plan's parallelizationEnabled is interpreted by the runner.
+@Suite(.serialized)
+struct NtfyTests {
+
 /// Tests for notification delivery fixes.
 ///
 /// Background: when a push arrives while the app is in the foreground, iOS calls
@@ -9,9 +21,6 @@ import CoreData
 /// never saved the message to CoreData, so it never appeared in the topic list (issue #337).
 ///
 /// These tests verify the fix and the Message parsing contract that the fix depends on.
-///
-/// Note: tests are serialized because Store(inMemory: true) uses /dev/null as the SQLite URL
-/// and parallel test processes can interfere with each other.
 @Suite(.serialized)
 struct NotificationDeliveryTests {
 
@@ -305,3 +314,5 @@ struct FirebaseTopicsTests {
                 "Different self-hosted servers with the same topic must produce different hashes")
     }
 }
+
+} // NtfyTests

--- a/ntfyTests/ntfyTests.swift
+++ b/ntfyTests/ntfyTests.swift
@@ -1,0 +1,16 @@
+//
+//  ntfyTests.swift
+//  ntfyTests
+//
+//  Created by Laurent FRANCOISE on 17/02/2026.
+//
+
+import Testing
+
+struct ntfyTests {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+}


### PR DESCRIPTION
## Summary

This PR fixes several notification delivery bugs, improves Firebase subscription robustness, adds persistent logging for diagnostics, and adds a comprehensive test suite with a reliable test plan.

### Bug fixes

**Notification delivery in foreground (fixes #337)**
- `willPresent` now saves the notification to CoreData. Previously it only showed a banner, so the notification never appeared in the topic list when the app was in the foreground or when the NSE was skipped (always the case on simulator).
- `didReceiveRemoteNotification` completionHandler is now called *after* all polls complete, using `DispatchGroup`. Previously it was called immediately, causing the system to suspend the app before polling finished.
- Firebase log level changed from `.max` to `.warning` (reduces noise in production logs).

**CoreData context refresh before background poll (related to #337)**
- `store.hardRefresh()` is called before building the `since=<lastNotificationId>` poll URL, so the main context reflects any recent NSE writes and doesn't re-fetch already-delivered messages.

**Idempotent notification save**
- `Store.save(notificationFromMessage:)` now checks for an existing notification with the same ID before inserting, preventing duplicates when NSE, `willPresent`, and background poll all deliver the same message through different paths.
- `Store(inMemory: true)` now uses `NSInMemoryStoreType` instead of the SQLite `/dev/null` trick, giving each test instance a fully isolated database.

**Firebase subscription robustness (#1305)**
- `subscribeToFirebaseTopics()` is now called on every app foreground (`didBecomeActive`) and on every background `~poll` push, in addition to `didReceiveRegistrationToken`. Firebase no-ops if already subscribed but retries previously failed subscriptions, recovering from silent failures caused by token rotation or network loss.
- Subscription errors are now logged (previously fire-and-forget with no visibility).

### New feature: persistent logs + share button

- All `Log.*` calls now write to `{AppGroupContainer}/ntfy.log` (shared between the main app and NSE) with 512 KB rotation.
- A **"Share logs"** button is added to Settings → About. Tapping it opens the system share sheet pre-filled with the log content and device info, so users experiencing delivery failures can send diagnostics without needing Xcode.

### Tests

14 unit tests covering:
- `Message.from(userInfo:)` parsing contract — string vs. integer fields (the silent nil return that caused #337)
- Idempotent `Store.save()` — duplicate and distinct IDs
- `willPresent` save logic — known topic, unknown topic, non-message events, deduplication
- `firebaseTopics()` mapping — ntfy.sh plain names, self-hosted SHA256 hashes, mixed subscriptions, collision resistance

`ntfy.xctestplan` added: `parallelizationEnabled=false` prevents xcodebuild from spawning multiple simulator clones. An outer `@Suite(.serialized)` wrapper prevents Swift Testing from running the two suites concurrently within the same process (concurrent `NSPersistentContainer` initialisation confuses CoreData's entity-class registration and can silently break relationship queries).

## Simulator limitations

The following delivery paths **cannot be verified on simulator** and require a real device with a valid APNs push certificate:

- **NSE path** (`xcrun simctl push` does not trigger the Notification Service Extension on simulator — known Apple limitation). The NSE fix is verified only by code review and by the fact that the `willPresent` fallback (which *is* testable on simulator) covers the same CoreData save logic.
- **FCM token rotation recovery** (#1305) — requires an actual Firebase project, a registered device token, and a deliberate token rotation (e.g. reinstall or network change). The unit tests verify the topic-mapping logic but not the live Firebase subscription round-trip.
- **Background `~poll` timing** — the `DispatchGroup` completionHandler fix prevents premature suspension, but iOS background execution time limits can only be observed on a real device.

All tests that *can* run on simulator pass: `xcodebuild test -scheme ntfy -destination 'platform=iOS Simulator,name=iPhone 17'` → **15/15 pass**.

## Test plan

- [ ] Build and run on simulator: send a push via `xcrun simctl push` while app is in foreground → notification appears in topic list (verifies `willPresent` fix)
- [ ] Run unit tests: `xcodebuild test -scheme ntfy -destination 'platform=iOS Simulator,name=iPhone 17'` → 15/15 pass
- [ ] Tap "Share logs" in Settings → About → share sheet appears with log content
- [ ] On a real device: subscribe to a topic → verify notifications appear in the topic list (NSE path)
- [ ] On a real device: force-quit and reinstall the app, then receive a push → verify delivery resumes (FCM re-subscription path)