### PR TITLE
feat(ios): add custom display names for subscriptions

### DIFF
--- a/ntfy/Persistence/Store.swift
+++ b/ntfy/Persistence/Store.swift
@@ -100,6 +100,11 @@ class Store: ObservableObject {
         return try? context.fetch(Subscription.fetchRequest())
     }
     
+    func updateSubscription(subscription: Subscription, displayName: String?) {
+        subscription.customDisplayName = (displayName?.isEmpty == true) ? nil : displayName
+        try? context.save()
+    }
+
     func delete(subscription: Subscription) {
         context.delete(subscription)
         try? context.save()

--- a/ntfy/Persistence/Subscription.swift
+++ b/ntfy/Persistence/Subscription.swift
@@ -6,6 +6,9 @@ extension Subscription {
     }
     
     func displayName() -> String {
+        if let customDisplayName = customDisplayName, !customDisplayName.isEmpty {
+            return customDisplayName
+        }
         return topicShortUrl(baseUrl: baseUrl ?? "?", topic: topic ?? "?")
     }
     

--- a/ntfy/Persistence/ntfy.xcdatamodeld/Model.xcdatamodel/contents
+++ b/ntfy/Persistence/ntfy.xcdatamodeld/Model.xcdatamodel/contents
@@ -22,6 +22,7 @@
     </entity>
     <entity name="Subscription" representedClassName="Subscription" syncable="YES" codeGenerationType="class">
         <attribute name="baseUrl" attributeType="String"/>
+        <attribute name="customDisplayName" optional="YES" attributeType="String"/>
         <attribute name="lastNotificationId" optional="YES" attributeType="String"/>
         <attribute name="topic" attributeType="String" minValueString="1" maxValueString="64" regularExpressionString="^[-_A-Za-z0-9]{1,64}$"/>
         <relationship name="notifications" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Notification" inverseName="subscription" inverseEntity="Notification"/>

--- a/ntfy/Views/NotificationListView.swift
+++ b/ntfy/Views/NotificationListView.swift
@@ -19,6 +19,8 @@ struct NotificationListView: View {
     
     @State private var showAlert = false
     @State private var activeAlert: ActiveAlert = .clear
+    @State private var showingRenameSheet = false
+    @State private var newDisplayName = ""
     
     private var subscriptionManager: SubscriptionManager {
         return SubscriptionManager(store: store)
@@ -82,6 +84,10 @@ struct NotificationListView: View {
                         }
                         if notificationsModel.notifications.count > 0 {
                             editButton
+                        }
+                        Button("Rename") {
+                            self.newDisplayName = subscription.customDisplayName ?? ""
+                            self.showingRenameSheet = true
                         }
                         Button("Send test notification") {
                             self.sendTestNotification()
@@ -167,6 +173,35 @@ struct NotificationListView: View {
         })
         .onAppear {
             cancelSubscriptionNotifications()
+        }
+        .sheet(isPresented: $showingRenameSheet) {
+            NavigationView {
+                Form {
+                    Section(header: Text("Display name")) {
+                        TextField(topicShortUrl(baseUrl: subscription.baseUrl ?? "", topic: subscription.topic ?? ""), text: $newDisplayName)
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                    }
+                    Section(footer: Text("Leave empty to show the default topic URL.")) {
+                        EmptyView()
+                    }
+                }
+                .navigationTitle("Rename")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button("Cancel") {
+                            showingRenameSheet = false
+                        }
+                    }
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button("Save") {
+                            store.updateSubscription(subscription: subscription, displayName: newDisplayName)
+                            showingRenameSheet = false
+                        }
+                    }
+                }
+            }
         }
     }
     


### PR DESCRIPTION
## Summary

Adds support for custom display names for subscriptions on iOS, bringing it to parity with the Android app and web app which already support this feature.

Closes #1314

## Changes

- **Core Data model**: Added optional `customDisplayName` attribute to the `Subscription` entity. The change is backwards compatible — existing installations will automatically migrate via Core Data's built-in lightweight migration (adding an optional attribute requires no manual migration mapping).
- **`Subscription.swift`**: Updated `displayName()` to return the custom name if set, falling back to the existing short URL display (`topicShortUrl()`).
- **`Store.swift`**: Added `updateSubscription(subscription:displayName:)` to persist the display name.
- **`NotificationListView.swift`**: Added "Rename" option to the subscription action menu. Tapping it opens a sheet where the user can enter a custom display name.

## Notes

- Setting the display name to empty restores the original URL-based display name
- No changes to `ntfyNSE` needed — display names are UI-only
