### PR TITLE
feat(ios): render Markdown in notification messages

### DIFF
--- a/ntfy/Persistence/Notification.swift
+++ b/ntfy/Persistence/Notification.swift
@@ -76,11 +76,18 @@ struct Message: Decodable {
     var actions: [Action]?
     var click: String?
     var pollId: String?
-    
+    var contentType: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, time, event, topic, message, title, priority, tags, actions, click
+        case pollId = "poll_id"
+        case contentType = "content_type"
+    }
+
     func toUserInfo() -> [AnyHashable: Any] {
         // This should mimic the way that the ntfy server encodes a message.
         // See server_firebase.go for more details.
-        
+
         return [
             "id": id,
             "time": String(time),
@@ -92,10 +99,11 @@ struct Message: Decodable {
             "tags": tags?.joined(separator: ",") ?? "",
             "actions": Actions.shared.encode(actions),
             "click": click ?? "",
-            "poll_id": pollId ?? ""
+            "poll_id": pollId ?? "",
+            "content_type": contentType ?? ""
         ]
     }
-    
+
     static func from(userInfo: [AnyHashable: Any]) -> Message? {
         guard let id = userInfo["id"] as? String,
               let time = userInfo["time"] as? String,
@@ -112,6 +120,7 @@ struct Message: Decodable {
         let actions = userInfo["actions"] as? String
         let click = userInfo["click"] as? String
         let pollId = userInfo["poll_id"] as? String
+        let contentType = userInfo["content_type"] as? String
         return Message(
             id: id,
             time: timeInt,
@@ -123,7 +132,8 @@ struct Message: Decodable {
             tags: tags,
             actions: Actions.shared.parse(actions),
             click: click,
-            pollId: pollId
+            pollId: pollId,
+            contentType: contentType
         )
     }
 }

--- a/ntfy/Persistence/Store.swift
+++ b/ntfy/Persistence/Store.swift
@@ -269,6 +269,7 @@ extension Store {
         notification.title = message.title
         notification.priority = message.priority ?? 3
         notification.tags = message.tags?.joined(separator: ",") ?? ""
+        notification.contentType = message.contentType
         return notification
     }
 }

--- a/ntfy/Persistence/ntfy.xcdatamodeld/Model.xcdatamodel/contents
+++ b/ntfy/Persistence/ntfy.xcdatamodeld/Model.xcdatamodel/contents
@@ -3,6 +3,7 @@
     <entity name="Notification" representedClassName="Notification" syncable="YES" codeGenerationType="class">
         <attribute name="actions" optional="YES" attributeType="String"/>
         <attribute name="click" optional="YES" attributeType="String"/>
+        <attribute name="contentType" optional="YES" attributeType="String"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="message" attributeType="String"/>
         <attribute name="priority" optional="YES" attributeType="Integer 16" minValueString="1" maxValueString="5" defaultValueString="3" usesScalarValueType="YES"/>

--- a/ntfy/Views/NotificationListView.swift
+++ b/ntfy/Views/NotificationListView.swift
@@ -287,8 +287,15 @@ struct NotificationRowView: View {
                     .bold()
                     .padding([.bottom], 2)
             }
-            Text(notification.formatMessage())
-                .font(.body)
+            if #available(iOS 15.0, *), notification.contentType == "text/markdown",
+               let attributed = try? AttributedString(markdown: notification.formatMessage(),
+                   options: AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlinesOnlyPreservingWhitespace)) {
+                Text(attributed)
+                    .font(.body)
+            } else {
+                Text(notification.formatMessage())
+                    .font(.body)
+            }
             if !notification.nonEmojiTags().isEmpty {
                 Text("Tags: " + notification.nonEmojiTags().joined(separator: ", "))
                     .font(.subheadline)


### PR DESCRIPTION
## Summary

This PR adds Markdown rendering support for iOS, closing #1072.

When a notification is published with `content_type: text/markdown` (i.e. using the `Content-Type: text/markdown` or `X-Content-Type: text/markdown` header), the message body is now rendered with proper formatting on **iOS 15+** instead of showing raw Markdown syntax like `**bold**`.

### What changed

- **`Message` struct** (`Notification.swift`): Added optional `contentType` field with `CodingKey` mapping from `content_type` (JSON snake_case). Also propagated through `toUserInfo()` and `from(userInfo:)` for push notification handling.
- **Core Data model** (`Model.xcdatamodel`): Added optional `contentType` String attribute to the `Notification` entity. This is a lightweight migration — no manual migration step needed; existing notifications without a content type will simply render as plain text (unchanged behaviour).
- **`Store.makeNotification()`**: Saves `contentType` from the incoming `Message`.
- **`NotificationRowView`** (`NotificationListView.swift`): When `contentType == "text/markdown"` and the device runs iOS 15+, the message is rendered via `AttributedString(markdown:)` with `.inlinesOnlyPreservingWhitespace` syntax. Falls back gracefully to plain `Text(...)` on iOS 14 and below, or when no content type is set.

### Example

Publishing with curl:
```sh
curl -H "Content-Type: text/markdown" -d "**Portfolio update**: BTC position +12.4% 🚀" https://ntfy.sh/mytopic
```

Before this PR: `**Portfolio update**: BTC position +12.4% 🚀`  
After this PR: **Portfolio update**: BTC position +12.4% 🚀

### Notes

- Android and the web app already support Markdown rendering — this brings iOS to parity.
- No breaking changes; the `contentType` Core Data attribute is optional and defaults to `nil`.
- `AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlinesOnlyPreservingWhitespace)` is used to avoid unwanted block-level formatting (e.g. headings, code blocks) in compact list rows.