### PR TITLE
feat: add ntfy:// URL scheme support for deep linking

### DIFF
--- a/ntfy.xcodeproj/project.pbxproj
+++ b/ntfy.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		94E9196C28353E0100F30170 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9474F216283531A200CDE4DD /* Log.swift */; };
 		E27008102AF0F64B006E33BA /* SubscriptionsObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E270080F2AF0F64B006E33BA /* SubscriptionsObservable.swift */; };
 		E27008122AF1030A006E33BA /* NotificationsObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27008112AF1030A006E33BA /* NotificationsObservable.swift */; };
+		F1A0B00128600000000AAAAA /* NtfyURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A0B00028600000000AAAAA /* NtfyURLHandler.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -115,6 +116,7 @@
 		94CD1969283E666900973B93 /* EmojiManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmojiManager.swift; sourceTree = "<group>"; };
 		E270080F2AF0F64B006E33BA /* SubscriptionsObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionsObservable.swift; sourceTree = "<group>"; };
 		E27008112AF1030A006E33BA /* NotificationsObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsObservable.swift; sourceTree = "<group>"; };
+		F1A0B00028600000000AAAAA /* NtfyURLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NtfyURLHandler.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -243,6 +245,7 @@
 				94867142283EC9950093C7A4 /* Actions.swift */,
 				948671462841B0B20093C7A4 /* NotificationContent.swift */,
 				948671492841D0CE0093C7A4 /* ActionExecutor.swift */,
+				F1A0B00028600000000AAAAA /* NtfyURLHandler.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -388,6 +391,7 @@
 				9474F1C1282F2AA700CDE4DD /* AppMain.swift in Sources */,
 				94867143283EC9960093C7A4 /* Actions.swift in Sources */,
 				9474F20F283326C500CDE4DD /* ApiService.swift in Sources */,
+				F1A0B00128600000000AAAAA /* NtfyURLHandler.swift in Sources */,
 				94B736D7284AF9BE003D69FB /* MainView.swift in Sources */,
 				9474F1F72830830700CDE4DD /* ntfy.xcdatamodeld in Sources */,
 				9407EDDA284ADE1F00C1C334 /* User.swift in Sources */,

--- a/ntfy/App/AppMain.swift
+++ b/ntfy/App/AppMain.swift
@@ -24,10 +24,44 @@ struct AppMain: App {
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
                     // Use this hook instead of applicationDidBecomeActive, see https://stackoverflow.com/a/68888509/1440785
                     // That post also explains how to start SwiftUI from AppDelegate if that's ever needed.
-                    
+
                     Log.d(tag, "App became active, refreshing objects")
                     store.hardRefresh()
                 }
+                .onOpenURL { url in
+                    handleNtfyURL(url)
+                }
+        }
+    }
+
+    /// Handle incoming ntfy:// deep link URLs.
+    ///
+    /// If the topic is already subscribed, navigates directly to it.
+    /// Otherwise, subscribes first and then navigates to the new subscription.
+    private func handleNtfyURL(_ url: URL) {
+        Log.d(tag, "Received deep link URL: \(url.absoluteString)")
+
+        guard let deepLink = NtfyDeepLink.from(url: url) else {
+            Log.w(tag, "Ignoring malformed ntfy:// URL: \(url.absoluteString)")
+            return
+        }
+
+        Log.d(tag, "Parsed deep link: baseUrl=\(deepLink.baseUrl), topic=\(deepLink.topic), display=\(deepLink.displayName ?? "nil")")
+
+        let subscriptionManager = SubscriptionManager(store: store)
+
+        // Subscribe if not already subscribed
+        if store.getSubscription(baseUrl: deepLink.baseUrl, topic: deepLink.topic) == nil {
+            Log.d(tag, "Topic not yet subscribed, subscribing to \(deepLink.baseUrl)/\(deepLink.topic)")
+            DispatchQueue.global(qos: .background).async {
+                subscriptionManager.subscribe(baseUrl: deepLink.baseUrl, topic: deepLink.topic)
+                DispatchQueue.main.async {
+                    delegate.selectedBaseUrl = topicUrl(baseUrl: deepLink.baseUrl, topic: deepLink.topic)
+                }
+            }
+        } else {
+            Log.d(tag, "Already subscribed to \(deepLink.baseUrl)/\(deepLink.topic), navigating")
+            delegate.selectedBaseUrl = topicUrl(baseUrl: deepLink.baseUrl, topic: deepLink.topic)
         }
     }
 }

--- a/ntfy/Info.plist
+++ b/ntfy/Info.plist
@@ -16,6 +16,17 @@
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<false/>
 	</dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>io.heckel.ntfy</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>ntfy</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>

--- a/ntfy/Utils/NtfyURLHandler.swift
+++ b/ntfy/Utils/NtfyURLHandler.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Represents a parsed ntfy:// deep link URL.
+///
+/// Supports the following formats (matching the Android app):
+///   - ntfy://host/topic
+///   - ntfy://host/topic?display=Name
+///   - ntfy://host/topic?secure=false
+///   - ntfy://host:port/topic
+///
+/// When `secure` is false, the base URL uses http:// instead of https://.
+struct NtfyDeepLink {
+    let baseUrl: String
+    let topic: String
+    let displayName: String?
+
+    /// Parse an ntfy:// URL into its components.
+    ///
+    /// Returns nil if the URL is malformed or missing required components (host, topic).
+    /// The topic is extracted from the first path component and validated against the
+    /// same regex used by the subscribe view: [-_A-Za-z0-9]{1,64}
+    static func from(url: URL) -> NtfyDeepLink? {
+        let tag = "NtfyDeepLink"
+
+        guard url.scheme == "ntfy" else {
+            Log.w(tag, "Ignoring URL with unexpected scheme: \(url.absoluteString)")
+            return nil
+        }
+
+        guard let host = url.host, !host.isEmpty else {
+            Log.w(tag, "Ignoring URL without host: \(url.absoluteString)")
+            return nil
+        }
+
+        // Extract topic from path — the first non-empty path component
+        let pathComponents = url.pathComponents.filter { $0 != "/" }
+        guard let topic = pathComponents.first, !topic.isEmpty else {
+            Log.w(tag, "Ignoring URL without topic: \(url.absoluteString)")
+            return nil
+        }
+
+        // Validate topic format (same regex as SubscriptionAddView)
+        guard topic.range(of: "^[-_A-Za-z0-9]{1,64}$", options: .regularExpression) != nil else {
+            Log.w(tag, "Ignoring URL with invalid topic '\(topic)': \(url.absoluteString)")
+            return nil
+        }
+
+        // Parse query parameters
+        let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        let secure = queryItems.first(where: { $0.name == "secure" })?.value != "false"
+        let displayName = queryItems.first(where: { $0.name == "display" })?.value
+
+        // Build base URL with scheme, host, and optional port
+        let scheme = secure ? "https" : "http"
+        let portSuffix = url.port.map { ":\($0)" } ?? ""
+        let baseUrl = "\(scheme)://\(host)\(portSuffix)"
+
+        return NtfyDeepLink(baseUrl: baseUrl, topic: topic, displayName: displayName)
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for `ntfy://` deep link URLs on iOS, matching the existing Android app behavior. This enables users to open subscription links directly in the iOS app.

### Supported URL formats

| Format | Example | Behavior |
|--------|---------|----------|
| `ntfy://host/topic` | `ntfy://ntfy.sh/mytopic` | Subscribe (if needed) and navigate to topic |
| `ntfy://host/topic?display=Name` | `ntfy://ntfy.sh/mytopic?display=My+Topic` | Same, with display name (parsed, ready for future use) |
| `ntfy://host/topic?secure=false` | `ntfy://example.com/mytopic?secure=false` | Uses HTTP instead of HTTPS |
| `ntfy://host:port/topic` | `ntfy://example.com:8080/mytopic` | Custom port support |

### Changes

- **`ntfy/Info.plist`** — Register `ntfy` URL scheme via `CFBundleURLTypes`
- **`ntfy/Utils/NtfyURLHandler.swift`** (new) — `NtfyDeepLink` struct that parses and validates `ntfy://` URLs
- **`ntfy/App/AppMain.swift`** — Wire up `.onOpenURL` to handle incoming deep links: auto-subscribe if needed, then navigate to the topic view

### Implementation notes

- Uses the existing `AppDelegate.selectedBaseUrl` mechanism for navigation (same pattern as notification tap handling)
- Topic validation uses the same regex as `SubscriptionAddView`: `[-_A-Za-z0-9]{1,64}`
- The `display` query parameter is parsed and available on the `NtfyDeepLink` struct but not yet wired to a display name field on `Subscription` (the Core Data model doesn't currently have one — this is ready for a follow-up)
- Error handling logs malformed URLs and silently ignores them (no user-facing error for bad deep links)

### Related

- Contributes to the iOS improvement roadmap tracked in binwiederhier/ntfy#1680
- Mirrors Android deep link support documented at https://ntfy.sh/docs/subscribe/phone/#ntfy-links

### Test plan

- [ ] Open `ntfy://ntfy.sh/test_deeplink` in Safari — app should open and subscribe to `test_deeplink` on ntfy.sh
- [ ] Open same URL again — should navigate to existing subscription without duplicating
- [ ] Test `ntfy://ntfy.sh/mytopic?secure=false` — should use `http://` base URL
- [ ] Test `ntfy://example.com:8080/mytopic` — should preserve custom port
- [ ] Test malformed URLs (`ntfy://`, `ntfy:///notopic`, `ntfy://host/inv@lid!`) — should be silently ignored with log output