### PR TITLE
Fix deleting notifications crash

### DIFF
--- a/ntfy/Persistence/Store.swift
+++ b/ntfy/Persistence/Store.swift
@@ -101,8 +101,10 @@ class Store: ObservableObject {
     }
     
     func delete(subscription: Subscription) {
-        context.delete(subscription)
-        try? context.save()
+        context.performAndWait {
+            context.delete(subscription)
+            try? context.save()
+        }
     }
     
     // MARK: Notifications
@@ -130,35 +132,41 @@ class Store: ObservableObject {
     }
     
     func delete(notification: Notification) {
-        Log.d(Store.tag, "Deleting notification \(notification.id ?? "")")
-        context.delete(notification)
-        try? context.save()
+        context.performAndWait {
+            Log.d(Store.tag, "Deleting notification \(notification.id ?? "")")
+            context.delete(notification)
+            try? context.save()
+        }
     }
     
     func delete(notifications: Set<Notification>) {
-        Log.d(Store.tag, "Deleting \(notifications.count) notification(s)")
-        do {
-            notifications.forEach { notification in
-                context.delete(notification)
+        context.performAndWait {
+            Log.d(Store.tag, "Deleting \(notifications.count) notification(s)")
+            do {
+                notifications.forEach { notification in
+                    context.delete(notification)
+                }
+                try context.save()
+            } catch let error {
+                Log.w(Store.tag, "Cannot delete notification(s)", error)
+                rollbackAndRefresh()
             }
-            try context.save()
-        } catch let error {
-            Log.w(Store.tag, "Cannot delete notification(s)", error)
-            rollbackAndRefresh()
         }
     }
     
     func delete(allNotificationsFor subscription: Subscription) {
-        guard let notifications = subscription.notifications else { return }
-        Log.d(Store.tag, "Deleting all \(notifications.count) notification(s) for subscription \(subscription.urlString())")
-        do {
-            notifications.forEach { notification in
-                context.delete(notification as! Notification)
+        context.performAndWait {
+            guard let notifications = subscription.notifications else { return }
+            Log.d(Store.tag, "Deleting all \(notifications.count) notification(s) for subscription \(subscription.urlString())")
+            do {
+                notifications.forEach { notification in
+                    context.delete(notification as! Notification)
+                }
+                try context.save()
+            } catch let error {
+                Log.w(Store.tag, "Cannot delete notification(s)", error)
+                rollbackAndRefresh()
             }
-            try context.save()
-        } catch let error {
-            Log.w(Store.tag, "Cannot delete notification(s)", error)
-            rollbackAndRefresh()
         }
     }
     

--- a/ntfy/Views/NotificationListView.swift
+++ b/ntfy/Views/NotificationListView.swift
@@ -206,23 +206,17 @@ struct NotificationListView: View {
     }
     
     private func unsubscribe() {
-        DispatchQueue.global(qos: .background).async {
-            subscriptionManager.unsubscribe(subscription)
-        }
+        subscriptionManager.unsubscribe(subscription)
         delegate.selectedBaseUrl = nil
     }
     
     private func deleteAll() {
-        DispatchQueue.global(qos: .background).async {
-            store.delete(allNotificationsFor: subscription)
-        }
+        store.delete(allNotificationsFor: subscription)
     }
     
     private func deleteSelected() {
-        DispatchQueue.global(qos: .background).async {
-            store.delete(notifications: selection)
-            selection = Set<Notification>()
-        }
+        store.delete(notifications: selection)
+        selection = Set<Notification>()
         editMode = .inactive
     }
     
@@ -346,4 +340,3 @@ struct NotificationListView_Previews: PreviewProvider {
         }
     }
 }
-


### PR DESCRIPTION
Addresses [#1642](https://github.com/binwiederhier/ntfy/issues/1642) [#377]( https://github.com/binwiederhier/ntfy/issues/377)

## The Fix
- Removed the explicit background queu from notification deletion actions in the notification list view
- Ensured Core Data delete/save operations for subscriptions and notifications run through the managed object context’s queue

There should be no more crashes or background thread warnings upon deleting notifications.