### PR TITLE
Honor action.clear by dismissing the notification on tap

### DIFF
--- a/ntfy/App/AppDelegate.swift
+++ b/ntfy/App/AppDelegate.swift
@@ -153,9 +153,11 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             selectedBaseUrl = topicUrl(baseUrl: baseUrl, topic: message.topic)
         }
         
-        // Execute user action or click action (if any)
+        // Execute user action or click action (if any). The notification identifier
+        // is forwarded so ActionExecutor can clear the delivered notification when
+        // the action has `clear: true` set.
         if let action = action {
-            ActionExecutor.execute(action)
+            ActionExecutor.execute(action, notificationId: response.notification.request.identifier)
         } else if let click = message.click, click != "", let url = URL(string: click) {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         }

--- a/ntfy/Utils/ActionExecutor.swift
+++ b/ntfy/Utils/ActionExecutor.swift
@@ -1,10 +1,15 @@
 import Foundation
 import UIKit
+import UserNotifications
 
 struct ActionExecutor {
     private static let tag = "ActionExecutor"
-        
-    static func execute(_ action: Action) {
+
+    /// Execute the given action. When `notificationId` is provided and the action's
+    /// `clear` flag is true, the matching delivered notification is also removed from
+    /// Notification Center so the user gets immediate visual confirmation that the
+    /// tap registered. Documented at https://docs.ntfy.sh/publish/#action-buttons
+    static func execute(_ action: Action, notificationId: String? = nil) {
         Log.d(tag, "Executing user action", action)
         switch action.action {
         case "view":
@@ -17,6 +22,10 @@ struct ActionExecutor {
             http(action)
         default:
             Log.w(tag, "Action \(action.action) not supported", action)
+        }
+
+        if action.clear == true, let id = notificationId {
+            UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [id])
         }
     }
     

--- a/ntfy/Views/NotificationListView.swift
+++ b/ntfy/Views/NotificationListView.swift
@@ -297,12 +297,12 @@ struct NotificationRowView: View {
                     ForEach(notification.actionsList()) { action in
                         if #available(iOS 15, *) {
                             Button(action.label) {
-                                ActionExecutor.execute(action)
+                                ActionExecutor.execute(action, notificationId: notification.id)
                             }
                             .buttonStyle(.borderedProminent)
                         } else {
                             Button(action: {
-                                ActionExecutor.execute(action)
+                                ActionExecutor.execute(action, notificationId: notification.id)
                             }) {
                                 Text(action.label)
                                     .padding(EdgeInsets(top: 10.0, leading: 10.0, bottom: 10.0, trailing: 10.0))


### PR DESCRIPTION
Closes binwiederhier/ntfy#1728.

## Problem

[ntfy action buttons](https://docs.ntfy.sh/publish/#action-buttons) support a `clear` flag that should dismiss the notification when the user taps the button. The iOS app already parses this field on `Action`:

```swift
struct Action: Encodable, Decodable, Identifiable {
    // ...
    var clear: Bool?
}
```

…but `ActionExecutor` never read it for `http` actions. So the notification stayed on the lock screen with no visual feedback after a tap. In a workflow like remote approval (the bug was originally reported via [claude-remote-approver](https://github.com/yuuichieguchi/claude-remote-approver)), users tap **Approve**, see nothing change, and either re-tap or worry the action didn't fire.

## Change

`ActionExecutor.execute` now takes an optional `notificationId`. When the action has `clear == true` *and* a `notificationId` was provided, the executor calls `UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers:)` after dispatching the action.

Call sites updated:

- `AppDelegate.userNotificationCenter(_:didReceive:)` — passes `response.notification.request.identifier` (same UUID used when the notification was created).
- `NotificationListView` (the in-app action button row) — passes `notification.id` so tapping an action from inside the app also dismisses any matching lock-screen notification.

The dismiss is fire-and-forget and runs alongside the (asynchronous) `URLSession` request; it does not wait for the HTTP response, matching user expectation of immediate feedback on tap. If the HTTP request later fails, the existing log path (`Log.e(...)` inside `http(_:)`) is unchanged.

## Why opt-in via parameter

`ActionExecutor` previously had no dependency on `UserNotifications` and no need for the notification identifier. Making `notificationId` an optional parameter keeps the contract minimal — call sites that don't have a notification (none today, but possible future ones) keep the existing `execute(action)` shape and simply skip the dismiss.

## Files changed

| File | Change |
| --- | --- |
| `ntfy/Utils/ActionExecutor.swift` | Add `import UserNotifications`, add `notificationId` param, dismiss on `clear == true` |
| `ntfy/App/AppDelegate.swift` | Pass `response.notification.request.identifier` |
| `ntfy/Views/NotificationListView.swift` | Pass `notification.id` at both call sites |

3 files changed, +17 / -6.

## Verification

I do not have an iOS build environment so I have not run the changes on a device. The diff is small enough to review by inspection — it's an additive optional parameter, a string identifier passed through, and a single new call to a documented `UNUserNotificationCenter` API. Happy to iterate on style/placement if there's a preferred pattern.

Confirmed end-to-end on the publisher side that ntfy 2.14.0 does forward `"clear": true` on actions to the iOS app — the message arrives intact, the field just isn't acted upon today. Same publisher-side fix has already been merged into the [Android app's reference behavior](https://docs.ntfy.sh/publish/#action-buttons) (per the docs).