### PR TITLE
Implement subscription activity sorting

### DIFF
--- a/ntfy.xcodeproj/project.pbxproj
+++ b/ntfy.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		9474F1E8282F3FFD00CDE4DD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9474F1F12830825600CDE4DD /* SubscriptionListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionListView.swift; sourceTree = "<group>"; };
 		9474F1F62830830700CDE4DD /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
+		E2A8F0012F9B000100000001 /* Model 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 2.xcdatamodel"; sourceTree = "<group>"; };
 		9474F1F82830835400CDE4DD /* Store.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Store.swift; sourceTree = "<group>"; };
 		9474F1FC2831311A00CDE4DD /* SubscriptionAddView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionAddView.swift; sourceTree = "<group>"; };
 		9474F1FE28316ACE00CDE4DD /* Subscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Subscription.swift; sourceTree = "<group>"; };
@@ -750,8 +751,9 @@
 			isa = XCVersionGroup;
 			children = (
 				9474F1F62830830700CDE4DD /* Model.xcdatamodel */,
+				E2A8F0012F9B000100000001 /* Model 2.xcdatamodel */,
 			);
-			currentVersion = 9474F1F62830830700CDE4DD /* Model.xcdatamodel */;
+			currentVersion = E2A8F0012F9B000100000001 /* Model 2.xcdatamodel */;
 			path = ntfy.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/ntfy/Persistence/Store.swift
+++ b/ntfy/Persistence/Store.swift
@@ -2,6 +2,24 @@ import Foundation
 import CoreData
 import Combine
 
+enum SubscriptionSortOrder: String, CaseIterable, Identifiable {
+    case alphabetical
+    case recentActivity
+
+    var id: String {
+        return rawValue
+    }
+
+    var label: String {
+        switch self {
+        case .alphabetical:
+            return "Alphabetical"
+        case .recentActivity:
+            return "Recent activity"
+        }
+    }
+}
+
 /// Handles all persistence in the app by storing/loading subscriptions and notifications using Core Data.
 /// There are sadly a lot of hacks in here, because I don't quite understand this fully.
 class Store: ObservableObject {
@@ -10,7 +28,10 @@ class Store: ObservableObject {
     static let appGroup = "group.io.heckel.ntfy" // Must match app group of ntfy = ntfyNSE targets
     static let modelName = "ntfy" // Must match .xdatamodeld folder
     static let prefKeyDefaultBaseUrl = "defaultBaseUrl"
-    
+    static let prefKeySubscriptionSortOrder = "subscriptionSortOrder"
+
+    @Published private(set) var subscriptionSortOrder: SubscriptionSortOrder = .alphabetical
+
     private let container: NSPersistentContainer
     var context: NSManagedObjectContext {
         return container.viewContext
@@ -22,6 +43,8 @@ class Store: ObservableObject {
             .containerURL(forSecurityApplicationGroupIdentifier: Store.appGroup)!
             .appendingPathComponent("ntfy.sqlite")
         let description = NSPersistentStoreDescription(url: storeUrl)
+        description.shouldMigrateStoreAutomatically = true
+        description.shouldInferMappingModelAutomatically = true
         description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
 
         // Set up container and observe changes from app extension
@@ -30,6 +53,11 @@ class Store: ObservableObject {
         container.loadPersistentStores { description, error in
             if let error = error {
                 Log.e(Store.tag, "Core Data failed to load: \(error.localizedDescription)", error)
+                return
+            }
+            DispatchQueue.main.async {
+                self.subscriptionSortOrder = self.getSubscriptionSortOrder()
+                self.backfillSubscriptionLastNotificationTimes()
             }
         }
         
@@ -123,6 +151,7 @@ class Store: ObservableObject {
 
         context.performAndWait {
             do {
+                var lastNotificationTime = subscription.lastNotificationTime
                 for message in messages {
                     let notification = Notification(context: context)
                     notification.id = message.id
@@ -136,8 +165,10 @@ class Store: ObservableObject {
                     notification.subscription = subscription
                     subscription.addToNotifications(notification)
                     subscription.lastNotificationId = message.id
+                    lastNotificationTime = max(lastNotificationTime, message.time)
                     Log.d(Store.tag, "Storing notification with ID \(notification.id ?? "<unknown>")")
                 }
+                subscription.lastNotificationTime = lastNotificationTime
                 try context.save()
             } catch let error {
                 Log.w(Store.tag, "Cannot store notifications (fromMessages)", error)
@@ -149,7 +180,11 @@ class Store: ObservableObject {
     func delete(notification: Notification) {
         context.performAndWait {
             Log.d(Store.tag, "Deleting notification \(notification.id ?? "")")
+            let subscription = notification.subscription
             context.delete(notification)
+            if let subscription = subscription {
+                updateLastNotificationTime(for: subscription)
+            }
             try? context.save()
         }
     }
@@ -158,9 +193,11 @@ class Store: ObservableObject {
         context.performAndWait {
             Log.d(Store.tag, "Deleting \(notifications.count) notification(s)")
             do {
+                let subscriptions = Set(notifications.compactMap { $0.subscription })
                 notifications.forEach { notification in
                     context.delete(notification)
                 }
+                subscriptions.forEach(updateLastNotificationTime)
                 try context.save()
             } catch let error {
                 Log.w(Store.tag, "Cannot delete notification(s)", error)
@@ -177,6 +214,7 @@ class Store: ObservableObject {
                 notifications.forEach { notification in
                     context.delete(notification as! Notification)
                 }
+                subscription.lastNotificationTime = 0
                 try context.save()
             } catch let error {
                 Log.w(Store.tag, "Cannot delete notification(s)", error)
@@ -225,6 +263,19 @@ class Store: ObservableObject {
         }
     }
     
+    func saveSubscriptionSortOrder(_ sortOrder: SubscriptionSortOrder) {
+        do {
+            let pref = getPreference(key: Store.prefKeySubscriptionSortOrder) ?? Preference(context: context)
+            pref.key = Store.prefKeySubscriptionSortOrder
+            pref.value = sortOrder.rawValue
+            try context.save()
+            subscriptionSortOrder = sortOrder
+        } catch let error {
+            Log.w(Store.tag, "Cannot store subscription sort order", error)
+            rollbackAndRefresh()
+        }
+    }
+
     func getDefaultBaseUrl() -> String {
         let baseUrl = getPreference(key: Store.prefKeyDefaultBaseUrl)?.value
         if baseUrl == nil || baseUrl?.isEmpty == true {
@@ -233,10 +284,53 @@ class Store: ObservableObject {
         return normalizeBaseUrl(baseUrl!)
     }
     
+    private func getSubscriptionSortOrder() -> SubscriptionSortOrder {
+        guard
+            let value = getPreference(key: Store.prefKeySubscriptionSortOrder)?.value,
+            let sortOrder = SubscriptionSortOrder(rawValue: value)
+        else {
+            return .alphabetical
+        }
+        return sortOrder
+    }
+
     private func getPreference(key: String) -> Preference? {
         let request = Preference.fetchRequest()
         request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [NSPredicate(format: "key = %@", key)])
         return try? context.fetch(request).first
+    }
+
+    private func backfillSubscriptionLastNotificationTimes() {
+        context.perform {
+            do {
+                let subscriptions = try self.context.fetch(Subscription.fetchRequest())
+                var hasChanges = false
+                for subscription in subscriptions {
+                    let lastNotificationTime = self.latestNotificationTime(for: subscription)
+                    if subscription.lastNotificationTime != lastNotificationTime {
+                        subscription.lastNotificationTime = lastNotificationTime
+                        hasChanges = true
+                    }
+                }
+                if hasChanges {
+                    try self.context.save()
+                }
+            } catch let error {
+                Log.w(Store.tag, "Cannot backfill subscription activity times", error)
+            }
+        }
+    }
+
+    private func updateLastNotificationTime(for subscription: Subscription) {
+        subscription.lastNotificationTime = latestNotificationTime(for: subscription)
+    }
+
+    private func latestNotificationTime(for subscription: Subscription) -> Int64 {
+        let request = Notification.fetchRequest()
+        request.predicate = NSPredicate(format: "subscription == %@", subscription)
+        request.sortDescriptors = [NSSortDescriptor(key: "time", ascending: false)]
+        request.fetchLimit = 1
+        return (try? context.fetch(request).first?.time) ?? 0
     }
 }
 
@@ -280,6 +374,7 @@ extension Store {
         subscription.baseUrl = Config.appBaseUrl
         subscription.topic = topic
         subscription.notifications = NSSet(array: notifications)
+        subscription.lastNotificationTime = messages.map(\.time).max() ?? 0
         return subscription
     }
     

--- a/ntfy/Persistence/SubscriptionsObservable.swift
+++ b/ntfy/Persistence/SubscriptionsObservable.swift
@@ -45,8 +45,32 @@ class SubscriptionsObservable: NSObject, ObservableObject {
         return controller
     }()
     
-    var subscriptions: [Subscription] {
-        fetchedResultsController.fetchedObjects ?? []
+    func subscriptions(sortOrder: SubscriptionSortOrder) -> [Subscription] {
+        let subscriptions = fetchedResultsController.fetchedObjects ?? []
+        switch sortOrder {
+        case .alphabetical:
+            return subscriptions
+        case .recentActivity:
+            return subscriptions.sorted { first, second in
+                if first.lastNotificationTime != second.lastNotificationTime {
+                    return first.lastNotificationTime > second.lastNotificationTime
+                }
+                return alphabeticallyPrecedes(first, second)
+            }
+        }
+    }
+
+    private func alphabeticallyPrecedes(_ first: Subscription, _ second: Subscription) -> Bool {
+        let firstTopic = first.topic ?? ""
+        let secondTopic = second.topic ?? ""
+        let topicComparison = firstTopic.localizedCaseInsensitiveCompare(secondTopic)
+        if topicComparison != .orderedSame {
+            return topicComparison == .orderedAscending
+        }
+
+        let firstBaseUrl = first.baseUrl ?? ""
+        let secondBaseUrl = second.baseUrl ?? ""
+        return firstBaseUrl.localizedCaseInsensitiveCompare(secondBaseUrl) == .orderedAscending
     }
 }
 

--- a/ntfy/Persistence/ntfy.xcdatamodeld/.xccurrentversion
+++ b/ntfy/Persistence/ntfy.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>_XCCurrentVersionName</key>
+    <string>Model 2.xcdatamodel</string>
+</dict>
+</plist>

--- a/ntfy/Persistence/ntfy.xcdatamodeld/Model 2.xcdatamodel/contents
+++ b/ntfy/Persistence/ntfy.xcdatamodeld/Model 2.xcdatamodel/contents
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Notification" representedClassName="Notification" syncable="YES" codeGenerationType="class">
+        <attribute name="actions" optional="YES" attributeType="String"/>
+        <attribute name="click" optional="YES" attributeType="String"/>
+        <attribute name="id" attributeType="String"/>
+        <attribute name="message" attributeType="String"/>
+        <attribute name="priority" optional="YES" attributeType="Integer 16" minValueString="1" maxValueString="5" defaultValueString="3" usesScalarValueType="YES"/>
+        <attribute name="tags" optional="YES" attributeType="String"/>
+        <attribute name="time" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <relationship name="subscription" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Subscription" inverseName="notifications" inverseEntity="Subscription"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="id"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="Preference" representedClassName="Preference" syncable="YES" codeGenerationType="class">
+        <attribute name="key" optional="YES" attributeType="String"/>
+        <attribute name="value" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="Subscription" representedClassName="Subscription" syncable="YES" codeGenerationType="class">
+        <attribute name="baseUrl" attributeType="String"/>
+        <attribute name="lastNotificationId" optional="YES" attributeType="String"/>
+        <attribute name="lastNotificationTime" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="topic" attributeType="String" minValueString="1" maxValueString="64" regularExpressionString="^[-_A-Za-z0-9]{1,64}$"/>
+        <relationship name="notifications" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Notification" inverseName="subscription" inverseEntity="Notification"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="baseUrl"/>
+                <constraint value="topic"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="User" representedClassName="User" syncable="YES" codeGenerationType="class">
+        <attribute name="baseUrl" attributeType="String"/>
+        <attribute name="password" attributeType="String"/>
+        <attribute name="username" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="baseUrl"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <elements>
+        <element name="Notification" positionX="-54" positionY="9" width="128" height="164"/>
+        <element name="Subscription" positionX="-262.4760131835938" positionY="11.46405029296875" width="128" height="104"/>
+        <element name="User" positionX="-162" positionY="81" width="128" height="74"/>
+        <element name="Preference" positionX="-162" positionY="81" width="128" height="59"/>
+    </elements>
+</model>

--- a/ntfy/Views/Settings/SettingsView.swift
+++ b/ntfy/Views/Settings/SettingsView.swift
@@ -11,9 +11,20 @@ struct SettingsView: View {
             Form {
                 Section(
                     header: Text("General"),
-                    footer: Text("When subscribing to new topics, this server will be used as a default.")
+                    footer: Text("Choose the default server for new topics and how subscribed topics are sorted.")
                 ) {
                     DefaultServerView()
+                    Picker(
+                        "Subscription sorting",
+                        selection: Binding(
+                            get: { store.subscriptionSortOrder },
+                            set: { store.saveSubscriptionSortOrder($0) }
+                        )
+                    ) {
+                        ForEach(SubscriptionSortOrder.allCases) { sortOrder in
+                            Text(sortOrder.label).tag(sortOrder)
+                        }
+                    }
                 }
                 Section(
                     header: Text("Users"),

--- a/ntfy/Views/SubscriptionListView.swift
+++ b/ntfy/Views/SubscriptionListView.swift
@@ -38,8 +38,9 @@ struct SubscriptionListView: View {
     }
     
     private var subscriptionList: some View {
-        List {
-            ForEach(subscriptionsModel.subscriptions) { subscription in
+        let subscriptions = subscriptionsModel.subscriptions(sortOrder: store.subscriptionSortOrder)
+        return List {
+            ForEach(subscriptions) { subscription in
                 SubscriptionItemNavView(subscription: subscription)
             }
         }
@@ -55,7 +56,7 @@ struct SubscriptionListView: View {
             }
         }
         .overlay(Group {
-            if subscriptionsModel.subscriptions.isEmpty {
+            if subscriptions.isEmpty {
                 VStack {
                     Text("It looks like you don't have any subscriptions yet")
                         .font(.title2)
@@ -84,7 +85,7 @@ struct SubscriptionListView: View {
     }
 
     private func pollSubscriptions() {
-        subscriptionsModel.subscriptions.forEach { subscription in
+        subscriptionsModel.subscriptions(sortOrder: store.subscriptionSortOrder).forEach { subscription in
             subscriptionManager.poll(subscription)
         }
     }


### PR DESCRIPTION
## Summary

Adds a subscription sorting setting to the iOS app so users can choose between alphabetical topic order and recent activity order. Recent activity uses the latest notification timestamp for each subscription, which makes the topic that just received a notification easier to find.

### Subscription activity tracking
- Added `lastNotificationTime` to the `Subscription` Core Data entity
- Updates `lastNotificationTime` when new notifications are saved
- Recomputes `lastNotificationTime` when notifications are deleted
- Backfills `lastNotificationTime` for existing subscriptions after the store loads

### Sorting preference
- Added a Settings picker for subscription sorting
- Supports alphabetical sorting and recent activity sorting
- Keeps alphabetical sorting as the default to preserve existing behavior
- Uses topic and base URL as stable tie-breakers for recent activity sorting

### Core Data migration
- Added a new Core Data model version for the subscription timestamp field
- Enabled lightweight migration for the persistent store

## Test plan
- [x] Ran `git diff --check`
- [x] Verified the iOS project builds with `xcodebuild` on a temporary macOS GitHub Actions workflow in my fork: https://github.com/swalusimbi/ntfy-ios/actions/runs/25902746084

Fixes binwiederhier/ntfy#1740
Related to binwiederhier/ntfy#1661