### PR TITLE
Fix force unwrap + remove unnecessary DispatchQueue

### DIFF
--- a/ntfy/Views/Notifications/NotificationListView.swift
+++ b/ntfy/Views/Notifications/NotificationListView.swift
@@ -208,19 +208,25 @@ struct NotificationListView: View {
     }
     
     private func sendTestNotification() {
+        guard let baseUrl = subscription.baseUrl else {
+            Log.w(tag, "Cannot send test notification: subscription base URL is missing")
+            return
+        }
+
         let possibleTags: Array<String> = ["warning", "skull", "success", "triangular_flag_on_post", "de", "us", "dog", "cat", "rotating_light", "bike", "backup", "rsync", "this-s-a-tag", "ios"]
         let priority = Int.random(in: 1..<6)
         let tags = Array(possibleTags.shuffled().prefix(Int.random(in: 0..<4)))
-        DispatchQueue.global(qos: .background).async {
-            let user = store.getUser(baseUrl: subscription.baseUrl!)?.toBasicUser()
-            ApiService.shared.publish(
-                subscription: subscription,
-                user: user,
-                message: "This is a test notification from the ntfy iOS app. It has a priority of \(priority). If you send another one, it may look different.",
-                title: "Test: You can set a title if you like",
-                priority: priority,
-                tags: tags
-            ) {
+
+        let user = store.getUser(baseUrl: baseUrl)?.toBasicUser()
+        ApiService.shared.publish(
+            subscription: subscription,
+            user: user,
+            message: "This is a test notification from the ntfy iOS app. It has a priority of \(priority). If you send another one, it may look different.",
+            title: "Test: You can set a title if you like",
+            priority: priority,
+            tags: tags
+        ) {
+            DispatchQueue.main.async {
                 subscriptionManager.poll(subscription)
             }
         }


### PR DESCRIPTION
This PR stops the force unwrapping of `subscription.baseUrl` and removes the unnecessary `DispatchQueue.global` when sending a test notification. This fixes a crash that was recently reported. 