### PR TITLE
Attachment improments

### DIFF
--- a/ntfy/Persistence/Store.swift
+++ b/ntfy/Persistence/Store.swift
@@ -257,22 +257,56 @@ class Store: ObservableObject {
         return basicUser
     }
 
-    func findSubscriptionMatch(forPollRequestTopic topic: String) -> (baseUrl: String, topic: String)? {
+    func findSubscriptionMatch(forPollRequestTopic topic: String, preferredBaseUrl: String? = nil) -> (baseUrl: String, topic: String)? {
         var match: (baseUrl: String, topic: String)?
         context.performAndWait {
             guard let subscriptions = try? context.fetch(Subscription.fetchRequest()) else {
+                Log.w(Store.tag, "\(#function): Can't find subscriptions with topic=\(topic)")
                 return
             }
-            match = subscriptions
-                .first {
-                    $0.urlHash() == topic || $0.topic == topic
-                }
-                .flatMap { subscription in
+            let normalizedPreferredBaseUrl = preferredBaseUrl.map(normalizeBaseUrl)
+            let normalizedDefaultBaseUrl = normalizeBaseUrl(Config.appBaseUrl)
+            let matchingSubscriptions = subscriptions.filter {
+                $0.urlHash() == topic || $0.topic == topic
+            }
+            Log.d(
+                Store.tag,
+                "\(#function) topic=\(topic) matched \(matchingSubscriptions.count) subscription(s)",
+                matchingSubscriptions.compactMap { subscription -> String? in
                     guard let baseUrl = subscription.baseUrl, let topic = subscription.topic else {
                         return nil
                     }
-                    return (baseUrl, topic)
+                    return topicUrl(baseUrl: baseUrl, topic: topic)
                 }
+            )
+
+            let prioritizedMatch = matchingSubscriptions.first {
+                guard let baseUrl = $0.baseUrl else {
+                    return false
+                }
+                if let normalizedPreferredBaseUrl {
+                    return normalizeBaseUrl(baseUrl) == normalizedPreferredBaseUrl
+                }
+                return false
+            } ?? matchingSubscriptions.first {
+                guard let baseUrl = $0.baseUrl, let subscriptionTopic = $0.topic else {
+                    return false
+                }
+                return subscriptionTopic == topic && normalizeBaseUrl(baseUrl) == normalizedDefaultBaseUrl
+            } ?? matchingSubscriptions.first
+
+            match = prioritizedMatch.flatMap { subscription in
+                guard let baseUrl = subscription.baseUrl, let topic = subscription.topic else {
+                    return nil
+                }
+                return (baseUrl, topic)
+            }
+            if match == nil {
+                Log.w(
+                    Store.tag,
+                    "\(#function) No poll request subscription match topic=\(topic) and preferredBaseUrl=\(normalizedPreferredBaseUrl ?? "<nil>")"
+                )
+            }
         }
         return match
     }

--- a/ntfy/Views/Notifications/NotificationAttachmentSectionView.swift
+++ b/ntfy/Views/Notifications/NotificationAttachmentSectionView.swift
@@ -112,8 +112,8 @@ struct NotificationAttachmentSectionView: View {
         .onChange(of: currentProgressState.persistedValue) { _ in
             syncPreparingAutoDownloadState(resolvedLocalFileUrl: resolvedLocalFileUrl)
         }
-        .task(id: imageAutoDownloadKey(resolvedLocalFileUrl: resolvedLocalFileUrl)) {
-            autoDownloadInlineImageIfNeeded(resolvedLocalFileUrl: resolvedLocalFileUrl)
+        .task(id: attachmentAutoDownloadKey(resolvedLocalFileUrl: resolvedLocalFileUrl)) {
+            autoDownloadAttachmentIfNeeded(resolvedLocalFileUrl: resolvedLocalFileUrl)
         }
     }
 
@@ -284,28 +284,27 @@ struct NotificationAttachmentSectionView: View {
         return false
     }
 
-    private func imageAutoDownloadKey(resolvedLocalFileUrl: URL?) -> String {
+    private func attachmentAutoDownloadKey(resolvedLocalFileUrl: URL?) -> String {
         [
             notification.id ?? "",
             resolvedLocalFileUrl?.path ?? ""
         ].joined(separator: "|")
     }
 
-    private func autoDownloadInlineImageIfNeeded(resolvedLocalFileUrl: URL?) {
+    private func autoDownloadAttachmentIfNeeded(resolvedLocalFileUrl: URL?) {
         syncPreparingAutoDownloadState(resolvedLocalFileUrl: resolvedLocalFileUrl)
-        guard shouldAutoDownloadInlineImage(resolvedLocalFileUrl: resolvedLocalFileUrl) else {
+        guard shouldAutoDownloadAttachment(resolvedLocalFileUrl: resolvedLocalFileUrl) else {
             isPreparingAutoDownload = false
-            if attachment.isImageAttachment(),
-               resolvedLocalFileUrl == nil,
+            if resolvedLocalFileUrl == nil,
                !attachmentExpired,
                currentProgressState == .none,
                !Store.shared.shouldAutoDownloadAttachment(attachment) {
-                Log.d("NotificationAttachmentSectionView", "Skipping inline auto-download for \(notification.id ?? "<nil>") because it exceeds the auto-download policy")
+                Log.d("NotificationAttachmentSectionView", "Skipping auto-download for \(notification.id ?? "<nil>") because it exceeds the auto-download policy")
                 notification.skipAttachmentAutoDownload()
             }
             return
         }
-        Log.d("NotificationAttachmentSectionView", "Starting inline auto-download for \(notification.id ?? "<nil>")")
+        Log.d("NotificationAttachmentSectionView", "Starting auto-download for \(notification.id ?? "<nil>")")
         controller.startDownload(
             notification: notification,
             attachment: attachment,
@@ -319,10 +318,7 @@ struct NotificationAttachmentSectionView: View {
         isPreparingAutoDownload || notification.isAttachmentDownloading(overrideState: currentProgressState)
     }
 
-    private func shouldAutoDownloadInlineImage(resolvedLocalFileUrl: URL?) -> Bool {
-        guard attachment.isImageAttachment() else {
-            return false
-        }
+    private func shouldAutoDownloadAttachment(resolvedLocalFileUrl: URL?) -> Bool {
         guard resolvedLocalFileUrl == nil else {
             return false
         }
@@ -351,6 +347,7 @@ struct NotificationAttachmentSectionView: View {
     }
 
     private func syncPreparingAutoDownloadState(resolvedLocalFileUrl: URL?) {
-        isPreparingAutoDownload = shouldAutoDownloadInlineImage(resolvedLocalFileUrl: resolvedLocalFileUrl)
+        isPreparingAutoDownload = attachment.isImageAttachment()
+            && shouldAutoDownloadAttachment(resolvedLocalFileUrl: resolvedLocalFileUrl)
     }
 }

--- a/ntfy/Views/Notifications/NotificationRowView.swift
+++ b/ntfy/Views/Notifications/NotificationRowView.swift
@@ -319,17 +319,47 @@ extension NotificationRowView {
     }
 
     @MainActor
-    private final class AttachmentExportPresenter: NSObject, UIDocumentPickerDelegate {
+    private final class AttachmentExportPresenter: NSObject, UIDocumentPickerDelegate, UIAdaptivePresentationControllerDelegate {
         static let shared = AttachmentExportPresenter()
+        private var activePicker: UIDocumentPickerViewController?
+        private var activeExportUrl: URL?
 
         func present(url: URL) {
             guard let presenter = topViewController(from: rootViewController()) else {
                 return
             }
 
-            let picker = UIDocumentPickerViewController(forExporting: [url], asCopy: true)
+            let exportUrl: URL
+            do {
+                exportUrl = try makeTemporaryExportCopy(of: url)
+            } catch {
+                Log.w("AttachmentExportPresenter", "Failed to prepare attachment export copy", error)
+                return
+            }
+
+            cleanupActiveExport()
+
+            let picker = UIDocumentPickerViewController(forExporting: [exportUrl], asCopy: true)
             picker.delegate = self
+            picker.presentationController?.delegate = self
+            activePicker = picker
+            activeExportUrl = exportUrl
             presenter.present(picker, animated: true)
+        }
+
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            cleanupIfActive(controller)
+        }
+
+        func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+            cleanupIfActive(controller)
+        }
+
+        func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+            guard let picker = presentationController.presentedViewController as? UIDocumentPickerViewController else {
+                return
+            }
+            cleanupIfActive(picker)
         }
 
         private func rootViewController() -> UIViewController? {
@@ -352,6 +382,32 @@ extension NotificationRowView {
                 return topViewController(from: presentedViewController)
             }
             return controller
+        }
+
+        private func cleanupIfActive(_ controller: UIDocumentPickerViewController) {
+            guard activePicker === controller else {
+                return
+            }
+            cleanupActiveExport()
+        }
+
+        private func cleanupActiveExport() {
+            activePicker = nil
+            if let activeExportUrl {
+                try? FileManager.default.removeItem(at: activeExportUrl)
+            }
+            activeExportUrl = nil
+        }
+
+        private func makeTemporaryExportCopy(of url: URL) throws -> URL {
+            let tempDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ntfy-export", isDirectory: true)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+            let destinationUrl = tempDir.appendingPathComponent("\(UUID().uuidString)-\(url.lastPathComponent)")
+            try? FileManager.default.removeItem(at: destinationUrl)
+            try FileManager.default.copyItem(at: url, to: destinationUrl)
+            return destinationUrl
         }
     }
 

--- a/ntfyNSE/NotificationService.swift
+++ b/ntfyNSE/NotificationService.swift
@@ -18,8 +18,6 @@ class NotificationService: UNNotificationServiceExtension {
         self.store = Store.shared
         self.contentHandler = contentHandler
         self.bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
-        
-        Log.d(tag, "Notification received (in service)") // Logs from extensions are not printed in Xcode!
 
         if let bestAttemptContent = bestAttemptContent {
             let userInfo = bestAttemptContent.userInfo
@@ -28,6 +26,10 @@ class NotificationService: UNNotificationServiceExtension {
                 contentHandler(request.content)
                 return
             }
+            Log.d(
+                tag,
+                "\(#function) event=\(message.event), topic=\(message.topic), pollId=\(message.pollId ?? "<nil>"), baseUrl=\(userInfo["base_url"] as? String ?? "<nil>")"
+            )
             switch message.event {
             case "poll_request":
                 handlePollRequest(request, bestAttemptContent, message, contentHandler)
@@ -45,7 +47,8 @@ class NotificationService: UNNotificationServiceExtension {
         // Called just before the extension will be terminated by the system.
         // Use this as an opportunity to deliver your "best attempt" at modified content,
         // otherwise the original push payload will be used.
-        
+
+        Log.w(tag, "\(#function): delivering best attempt content")
         if let contentHandler = contentHandler, let bestAttemptContent =  bestAttemptContent {
             contentHandler(bestAttemptContent)
         }
@@ -67,8 +70,11 @@ class NotificationService: UNNotificationServiceExtension {
     
     private func handlePollRequest(_ request: UNNotificationRequest, _ content: UNMutableNotificationContent, _ pollRequest: Message, _ contentHandler: @escaping (UNNotificationContent) -> Void) {
         let pollId = pollRequest.pollId ?? pollRequest.id
-        guard
-            let subscription = store?.findSubscriptionMatch(forPollRequestTopic: pollRequest.topic)
+        let preferredBaseUrl = bestAttemptContent?.userInfo["base_url"] as? String
+        guard let subscription = store?.findSubscriptionMatch(
+                forPollRequestTopic: pollRequest.topic,
+                preferredBaseUrl: preferredBaseUrl
+            )
         else {
             Log.w(tag, "Cannot find subscription for poll request topic=\(pollRequest.topic), pollId=\(pollRequest.pollId ?? "<nil>")")
             contentHandler(request.content)


### PR DESCRIPTION
This addresses three issues reported from TestFlight feedback and discord:
- attachment auto download settings only applied to images
- saving a downloaded attachment could leave the exported file “in use” so it couldn't be deleted in files
- protected topic push notifications could sometimes remain as "New message" instead of resolving the real content (I am not 100% sure this is fixed, so I improved the logging also)
