### PR TITLE
Add setting for critical alerts toggle

### DIFF
--- a/ntfy.xcodeproj/project.pbxproj
+++ b/ntfy.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		2939B21B2F8F293C00A52946 /* UserTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2939B2142F8F293C00A52946 /* UserTableView.swift */; };
 		2968F2AD2FBA530200480665 /* AttachmentProgressState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2968F2AC2FBA530200480665 /* AttachmentProgressState.swift */; };
 		2968F2AE2FBA530200480665 /* AttachmentProgressState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2968F2AC2FBA530200480665 /* AttachmentProgressState.swift */; };
+		29B4EB062FD7C5C1005CA516 /* CriticalAlertsSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B4EB052FD7C5C1005CA516 /* CriticalAlertsSettingView.swift */; };
 		29C6D8312FBD1B750057C9AC /* DownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C6D8302FBD1B750057C9AC /* DownloadDelegate.swift */; };
 		29C6D8322FBD1B750057C9AC /* DownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C6D8302FBD1B750057C9AC /* DownloadDelegate.swift */; };
 		29E8419B2FB417E400F927E4 /* SubscriptionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29E841992FB417E400F927E4 /* SubscriptionListView.swift */; };
@@ -105,6 +106,7 @@
 		2939B2132F8F293C00A52946 /* UserRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRowView.swift; sourceTree = "<group>"; };
 		2939B2142F8F293C00A52946 /* UserTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTableView.swift; sourceTree = "<group>"; };
 		2968F2AC2FBA530200480665 /* AttachmentProgressState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentProgressState.swift; sourceTree = "<group>"; };
+		29B4EB052FD7C5C1005CA516 /* CriticalAlertsSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CriticalAlertsSettingView.swift; sourceTree = "<group>"; };
 		29C6D8302FBD1B750057C9AC /* DownloadDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadDelegate.swift; sourceTree = "<group>"; };
 		29E841982FB417E400F927E4 /* SubscriptionAddView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionAddView.swift; sourceTree = "<group>"; };
 		29E841992FB417E400F927E4 /* SubscriptionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionListView.swift; sourceTree = "<group>"; };
@@ -174,6 +176,7 @@
 				18A28C5B2FBCF00000A52946 /* AttachmentAutoDownloadView.swift */,
 				2939B2102F8F293C00A52946 /* DefaultServerView.swift */,
 				2939B2112F8F293C00A52946 /* SettingsView.swift */,
+				29B4EB052FD7C5C1005CA516 /* CriticalAlertsSettingView.swift */,
 				2939B2122F8F293C00A52946 /* UserEditorView.swift */,
 				2939B2132F8F293C00A52946 /* UserRowView.swift */,
 				2939B2142F8F293C00A52946 /* UserTableView.swift */,
@@ -469,6 +472,7 @@
 				9474F1F72830830700CDE4DD /* ntfy.xcdatamodeld in Sources */,
 				29E841A52FB417EA00F927E4 /* NotificationAttachmentController.swift in Sources */,
 				29E841A62FB417EA00F927E4 /* NotificationRowView.swift in Sources */,
+				29B4EB062FD7C5C1005CA516 /* CriticalAlertsSettingView.swift in Sources */,
 				29E841A72FB417EA00F927E4 /* NotificationAttachmentImageLoader.swift in Sources */,
 				29E841A82FB417EA00F927E4 /* NotificationAttachmentImageView.swift in Sources */,
 				29E841A92FB417EA00F927E4 /* AttachmentFileStore.swift in Sources */,

--- a/ntfy/App/AppDelegate.swift
+++ b/ntfy/App/AppDelegate.swift
@@ -12,6 +12,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ObservableObject {
     
     // Implements navigation from notifications, see https://stackoverflow.com/a/70731861/1440785
     @Published var selectedBaseUrl: String? = nil
+    @Published private(set) var criticalAlertSetting: UNNotificationSetting = .notSupported
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         Log.d(tag, "Launching AppDelegate")
@@ -22,19 +23,73 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ObservableObject {
         // Register app permissions for push notifications
         UNUserNotificationCenter.current().delegate = self
         Messaging.messaging().delegate = self
+        requestStandardNotificationAuthorization()
+        refreshNotificationSettings()
         
+        // Register too receive remote notifications
+        application.registerForRemoteNotifications()
+                
+        return true
+    }
+
+    func refreshNotificationSettings(completion: (() -> Void)? = nil) {
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            let isAuthorized = settings.criticalAlertSetting == .enabled
+            DispatchQueue.main.async {
+                self.criticalAlertSetting = settings.criticalAlertSetting
+                Store.saveCriticalAlertsAuthorized(isAuthorized)
+                completion?()
+            }
+        }
+    }
+
+    func requestCriticalAlertsAuthorization(completion: @escaping (Bool) -> Void) {
+        if criticalAlertSetting == .enabled {
+            completion(true)
+            return
+        }
+
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound, .criticalAlert]) { success, error in
+            if let error {
+                Log.e(self.tag, "Failed to register for critical alerts", error)
+            } else if success {
+                Log.d(self.tag, "Successfully requested critical alerts")
+            }
+
+            self.refreshNotificationSettings {
+                completion(self.criticalAlertSetting == .enabled)
+            }
+        }
+    }
+
+    // TODO: Needs to be tested on multiple devices/iOS versions
+    func openNotificationSettings() {
+        let settingsURLString: String
+        #if targetEnvironment(simulator)
+        settingsURLString = UIApplication.openSettingsURLString
+        #else
+        if #available(iOS 16.0, *) {
+            settingsURLString = UIApplication.openNotificationSettingsURLString
+        } else if #available(iOS 15.4, *) {
+            settingsURLString = UIApplicationOpenNotificationSettingsURLString
+        } else {
+            settingsURLString = UIApplication.openSettingsURLString
+        }
+        #endif
+        guard let url = URL(string: settingsURLString) else {
+            return
+        }
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+    }
+
+    private func requestStandardNotificationAuthorization() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { success, error in
             guard success else {
                 Log.e(self.tag, "Failed to register for local push notifications", error)
                 return
             }
             Log.d(self.tag, "Successfully registered for local push notifications")
         }
-        
-        // Register too receive remote notifications
-        application.registerForRemoteNotifications()
-                
-        return true
     }
     
     /// Executed when a background notification arrives on the "~poll" topic. This is used to trigger polling of local topics.

--- a/ntfy/App/AppMain.swift
+++ b/ntfy/App/AppMain.swift
@@ -27,8 +27,8 @@ struct AppMain: App {
                     
                     Log.d(tag, "App became active, refreshing objects")
                     store.hardRefresh()
+                    delegate.refreshNotificationSettings()
                 }
         }
     }
 }
-

--- a/ntfy/Persistence/Store.swift
+++ b/ntfy/Persistence/Store.swift
@@ -25,6 +25,7 @@ class Store: ObservableObject {
     static let modelName = "ntfy" // Must match .xdatamodeld folder
     static let prefKeyDefaultBaseUrl = "defaultBaseUrl"
     static let prefKeyAttachmentAutoDownloadMaxSize = "attachmentAutoDownloadMaxSize"
+    static let prefKeyCriticalAlertsEnabled = "criticalAlertsEnabled"
     static let autoDownloadNever = Constants.autoDownloadNever
     static let autoDownloadAlways = Constants.autoDownloadAlways
     static let autoDownload100KB = Constants.autoDownload100KB
@@ -33,6 +34,8 @@ class Store: ObservableObject {
     static let autoDownload5MB = Constants.autoDownload5MB
     static let autoDownload10MB = Constants.autoDownload10MB
     static let autoDownload50MB = Constants.autoDownload50MB
+    private static let sharedDefaults = UserDefaults(suiteName: Store.appGroup)!
+    private static let sharedDefaultsKeyCriticalAlertsAuthorized = "criticalAlertsAuthorized"
     private let container: NSPersistentContainer
     var context: NSManagedObjectContext {
         return container.viewContext
@@ -358,6 +361,30 @@ class Store: ObservableObject {
             Log.w(Store.tag, "Cannot store attachment auto-download preference", error)
             rollbackAndRefresh()
         }
+    }
+
+    func getCriticalAlertsEnabled() -> Bool {
+        getPreference(key: Store.prefKeyCriticalAlertsEnabled)?.value == "true"
+    }
+
+    func saveCriticalAlertsEnabled(_ enabled: Bool) {
+        do {
+            let pref = getPreference(key: Store.prefKeyCriticalAlertsEnabled) ?? Preference(context: context)
+            pref.key = Store.prefKeyCriticalAlertsEnabled
+            pref.value = String(enabled)
+            try context.save()
+        } catch let error {
+            Log.w(Store.tag, "Cannot store critical alerts preference", error)
+            rollbackAndRefresh()
+        }
+    }
+
+    static func getCriticalAlertsAuthorized() -> Bool {
+        sharedDefaults.bool(forKey: sharedDefaultsKeyCriticalAlertsAuthorized)
+    }
+
+    static func saveCriticalAlertsAuthorized(_ enabled: Bool) {
+        sharedDefaults.set(enabled, forKey: sharedDefaultsKeyCriticalAlertsAuthorized)
     }
 
     func shouldAutoDownloadAttachment(_ attachment: MessageAttachment) -> Bool {

--- a/ntfy/Utils/NotificationContent.swift
+++ b/ntfy/Utils/NotificationContent.swift
@@ -36,7 +36,8 @@ extension UNMutableNotificationContent {
         // permissions. This is described in https://stackoverflow.com/a/44580916/1440785
         configureNotificationActions(message: message)
         
-        // Group by topic, and use a critical sound for highest-priority alerts.
+        // Group by topic, and only elevate priority 5 alerts to critical when the user opted in
+        // and iOS has granted critical alert permission.
         self.threadIdentifier = topicUrl(baseUrl: baseUrl, topic: message.topic)
         
         // Map priorities to interruption level (light up screen, ...) and relevance (order)
@@ -54,8 +55,13 @@ extension UNMutableNotificationContent {
             self.interruptionLevel = .timeSensitive
             self.relevanceScore = 0.75
         case 5:
-            self.sound = .defaultCritical
-            self.interruptionLevel = .critical
+            if Store.shared.getCriticalAlertsEnabled() && Store.getCriticalAlertsAuthorized() {
+                self.sound = .defaultCritical
+                self.interruptionLevel = .critical
+            } else {
+                self.sound = .default
+                self.interruptionLevel = .timeSensitive
+            }
             self.relevanceScore = 1
         default:
             self.sound = .default

--- a/ntfy/Views/Settings/CriticalAlertsSettingView.swift
+++ b/ntfy/Views/Settings/CriticalAlertsSettingView.swift
@@ -1,0 +1,52 @@
+//
+//  CriticalAlertsSettingView.swift
+//  ntfy
+//
+//  Created by Alek Michelson on 6/8/26.
+//
+
+import SwiftUI
+
+struct CriticalAlertsSettingView: View {
+    @EnvironmentObject private var store: Store
+    @EnvironmentObject private var delegate: AppDelegate
+    @FetchRequest(sortDescriptors: []) private var prefs: FetchedResults<Preference>
+    @State private var showingSettingsAlert = false
+
+    private var criticalAlertsEnabled: Bool {
+        prefs
+            .first { $0.key == Store.prefKeyCriticalAlertsEnabled }?
+            .value == "true"
+    }
+
+    var body: some View {
+        Toggle("Critical alerts for priority 5", isOn: Binding(
+            get: { criticalAlertsEnabled },
+            set: handleToggleChanged
+        ))
+        .alert("Enable Critical Alerts", isPresented: $showingSettingsAlert) {
+            Button("Open Notification Settings") {
+                delegate.openNotificationSettings()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Critical alerts were not allowed. You can enable them in the iOS notification settings for ntfy.")
+        }
+    }
+
+    private func handleToggleChanged(_ enabled: Bool) {
+        guard enabled else {
+            store.saveCriticalAlertsEnabled(false)
+            return
+        }
+
+        delegate.requestCriticalAlertsAuthorization { isAuthorized in
+            if isAuthorized {
+                store.saveCriticalAlertsEnabled(true)
+            } else {
+                store.saveCriticalAlertsEnabled(false)
+                showingSettingsAlert = true
+            }
+        }
+    }
+}

--- a/ntfy/Views/Settings/CriticalAlertsSettingView.swift
+++ b/ntfy/Views/Settings/CriticalAlertsSettingView.swift
@@ -20,10 +20,19 @@ struct CriticalAlertsSettingView: View {
     }
 
     var body: some View {
-        Toggle("Critical alerts for priority 5", isOn: Binding(
+        Toggle(isOn: Binding(
             get: { criticalAlertsEnabled },
             set: handleToggleChanged
-        ))
+        )) {
+            HStack(spacing: 14) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(.red)
+                    .font(.system(size: 22))
+
+                Text("Critical Alerts")
+                    .foregroundColor(.primary)
+            }
+        }
         .alert("Enable Critical Alerts", isPresented: $showingSettingsAlert) {
             Button("Open Notification Settings") {
                 delegate.openNotificationSettings()

--- a/ntfy/Views/Settings/SettingsView.swift
+++ b/ntfy/Views/Settings/SettingsView.swift
@@ -22,8 +22,7 @@ struct SettingsView: View {
                     AttachmentAutoDownloadView()
                 }
                 Section(
-                    header: Text("Critical alerts"),
-                    footer: Text("When enabled, priority 5 messages are delivered as critical alerts after iOS grants permission.")
+                    footer: Text("Priority 5 notifications appear on the Lock Screen and play a sound even if a Focus is on or iPhone is muted.")
                 ) {
                     CriticalAlertsSettingView()
                 }

--- a/ntfy/Views/Settings/SettingsView.swift
+++ b/ntfy/Views/Settings/SettingsView.swift
@@ -4,6 +4,7 @@ import StoreKit
 
 struct SettingsView: View {
     @EnvironmentObject private var store: Store
+    @EnvironmentObject private var delegate: AppDelegate
     @State private var userDialog: UserDialog?
     
     var body: some View {
@@ -19,6 +20,12 @@ struct SettingsView: View {
                     header: Text("Notifications")
                 ) {
                     AttachmentAutoDownloadView()
+                }
+                Section(
+                    header: Text("Critical alerts"),
+                    footer: Text("When enabled, priority 5 messages are delivered as critical alerts after iOS grants permission.")
+                ) {
+                    CriticalAlertsSettingView()
                 }
                 Section(
                     header: Text("Users"),
@@ -51,7 +58,6 @@ struct SettingsView: View {
         .navigationViewStyle(StackNavigationViewStyle())
     }
 }
-
 
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {


### PR DESCRIPTION
- Add a new Critical alerts section in Settings with a toggle to treat Priority 5 notifications as critical alerts
- Persist the toggle state and request critical alert permission only when the user enables it
- Map Priority 5 to .critical only when the toggle is on and iOS has granted critical alert authorization; otherwise fall back to time-sensitive
- Add a settings redirect for denied authorization and refresh notification settings when the app becomes activ