### PR TITLE
✨ Render Markdown messages

### DIFF
--- a/ntfy/Persistence/Notification.swift
+++ b/ntfy/Persistence/Notification.swift
@@ -46,6 +46,11 @@ extension Notification {
         return nil
     }
     
+    /// Whether the stored message should be rendered as Markdown (see `Message.isMarkdown`).
+    var isMarkdown: Bool {
+        Message.isMarkdownContentType(contentType)
+    }
+
     func emojiTags() -> [String] {
         return parseEmojiTags(tags)
     }
@@ -262,6 +267,23 @@ extension Notification {
     }
 }
 
+/// Renders a Markdown string down to clean plain text, dropping the formatting markers
+/// (`**`, `_`, `#`, link syntax, …). Used for surfaces that cannot display rich text, such as
+/// the system notification banner — APNs strips any styling from the banner, so showing the raw
+/// `**markers**` there just looks broken. Falls back to the original string if parsing fails.
+func markdownToPlainText(_ source: String) -> String {
+    let options: AttributedString.MarkdownParsingOptions
+    if #available(iOS 16.0, *) {
+        options = .init(interpretedSyntax: .inlineOnlyPreservingWhitespace, failurePolicy: .returnPartiallyParsedIfPossible)
+    } else {
+        options = .init(interpretedSyntax: .inlineOnly, failurePolicy: .returnPartiallyParsedIfPossible)
+    }
+    guard let attributed = try? AttributedString(markdown: source, options: options) else {
+        return source
+    }
+    return String(attributed.characters)
+}
+
 struct MessageAttachment: Codable {
     var name: String
     var type: String?
@@ -336,10 +358,24 @@ struct Message: Decodable {
     var click: String?
     var pollId: String?
     var attachment: MessageAttachment?
+    var contentType: String?
 
     enum CodingKeys: String, CodingKey {
         case id, time, event, topic, message, title, priority, tags, actions, click, attachment
         case pollId = "poll_id"
+        case contentType = "content_type"
+    }
+
+    /// Whether the message body should be rendered as Markdown, as indicated by the server's
+    /// `content_type` (set when a message is published with the `Markdown: true` header).
+    var isMarkdown: Bool {
+        Message.isMarkdownContentType(contentType)
+    }
+
+    /// Returns true if the given content type denotes Markdown. Tolerates an optional charset
+    /// suffix, e.g. `text/markdown; charset=utf-8`.
+    static func isMarkdownContentType(_ contentType: String?) -> Bool {
+        contentType?.lowercased().hasPrefix("text/markdown") ?? false
     }
 
     init(
@@ -354,7 +390,8 @@ struct Message: Decodable {
         actions: [Action]? = nil,
         click: String? = nil,
         pollId: String? = nil,
-        attachment: MessageAttachment? = nil
+        attachment: MessageAttachment? = nil,
+        contentType: String? = nil
     ) {
         self.id = id
         self.time = time
@@ -368,6 +405,7 @@ struct Message: Decodable {
         self.click = click
         self.pollId = pollId
         self.attachment = attachment
+        self.contentType = contentType
     }
 
     init(from decoder: Decoder) throws {
@@ -384,6 +422,7 @@ struct Message: Decodable {
         click = try container.decodeIfPresent(String.self, forKey: .click)
         pollId = try container.decodeIfPresent(String.self, forKey: .pollId)
         attachment = try container.decodeIfPresent(MessageAttachment.self, forKey: .attachment)
+        contentType = try container.decodeIfPresent(String.self, forKey: .contentType)
     }
     
     func toUserInfo() -> [AnyHashable: Any] {
@@ -401,7 +440,8 @@ struct Message: Decodable {
             "tags": tags?.joined(separator: ",") ?? "",
             "actions": Actions.shared.encode(actions),
             "click": click ?? "",
-            "poll_id": pollId ?? ""
+            "poll_id": pollId ?? "",
+            "content_type": contentType ?? ""
         ]
         if let attachment {
             userInfo["attachment_name"] = attachment.name
@@ -429,6 +469,7 @@ struct Message: Decodable {
         let actions = userInfo["actions"] as? String
         let click = userInfo["click"] as? String
         let pollId = userInfo["poll_id"] as? String
+        let contentType = userInfo["content_type"] as? String
         let attachmentUrl = userInfo["attachment_url"] as? String
         let attachment: MessageAttachment?
         if let attachmentUrl = attachmentUrl, !attachmentUrl.isEmpty {
@@ -454,7 +495,8 @@ struct Message: Decodable {
             actions: Actions.shared.parse(actions),
             click: click,
             pollId: pollId,
-            attachment: attachment
+            attachment: attachment,
+            contentType: contentType
         )
     }
 }

--- a/ntfy/Persistence/Store.swift
+++ b/ntfy/Persistence/Store.swift
@@ -459,6 +459,7 @@ class Store: ObservableObject {
             notification.tags = message.tags?.joined(separator: ",") ?? ""
             notification.actions = Actions.shared.encode(message.actions)
             notification.click = message.click ?? ""
+            notification.contentType = message.contentType
             notification.attachmentName = message.attachment?.name
             notification.attachmentType = message.attachment?.type
             notification.attachmentSize = message.attachment?.size ?? 0
@@ -504,7 +505,9 @@ extension Store {
             Message(id: "3", time: 1643058956, event: "message", topic: "stats", message: "This message does not have a title, but is instead super long. Like really really long. It can't be any longer I think. I mean, there is s 4,000 byte limit of the message, so I guess I have to make this 4,000 bytes long. Or do I? 😁 I don't know. It's quite tedious to come up with something so long, so I'll stop now. Bye!", title: nil, priority: 5, tags: ["facepalm"], actions: nil)
         ],
         "backups": [],
-        "announcements": [],
+        "announcements": [
+            Message(id: "md1", time: 1653048956, event: "message", topic: "announcements", message: "**Bold**, *italic*, ~~strike~~ and `inline code` all render. Plus a [link](https://ntfy.sh) and a bare URL https://docs.ntfy.sh\n\n- first item\n- second item", title: "Markdown release 🎉", priority: 3, tags: ["tada"], actions: nil, contentType: "text/markdown")
+        ],
         "alerts": [],
         "playground": []
     ]
@@ -538,6 +541,7 @@ extension Store {
             notification.title = message.title
             notification.priority = message.priority ?? 3
             notification.tags = message.tags?.joined(separator: ",") ?? ""
+            notification.contentType = message.contentType
             notification.attachmentName = message.attachment?.name
             notification.attachmentType = message.attachment?.type
             notification.attachmentSize = message.attachment?.size ?? 0

--- a/ntfy/Persistence/ntfy.xcdatamodeld/Model.xcdatamodel/contents
+++ b/ntfy/Persistence/ntfy.xcdatamodeld/Model.xcdatamodel/contents
@@ -10,6 +10,7 @@
         <attribute name="attachmentType" optional="YES" attributeType="String"/>
         <attribute name="attachmentUrl" optional="YES" attributeType="String"/>
         <attribute name="click" optional="YES" attributeType="String"/>
+        <attribute name="contentType" optional="YES" attributeType="String"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="message" attributeType="String"/>
         <attribute name="priority" optional="YES" attributeType="Integer 16" minValueString="1" maxValueString="5" defaultValueString="3" usesScalarValueType="YES"/>

--- a/ntfy/Utils/NotificationContent.swift
+++ b/ntfy/Utils/NotificationContent.swift
@@ -5,7 +5,9 @@ extension UNMutableNotificationContent {
     func modify(message: Message, baseUrl: String) {
         // Body and title
         if let body = message.message {
-            self.body = body
+            // The notification banner can't render rich text, so for Markdown messages we strip
+            // the formatting markers to clean plain text rather than showing raw `**`/`_`/`#`.
+            self.body = message.isMarkdown ? markdownToPlainText(body) : body
         }
         
         // Set notification title to short URL if there is no title. The title is always set

--- a/ntfy/Views/Extensions.swift
+++ b/ntfy/Views/Extensions.swift
@@ -3,17 +3,67 @@ import SwiftUI
 // MARK: Extensions
 
 extension Notification {
-    func linkifiedMessageAttributedString() -> AttributedString {
-        let source = formatMessage()
-        let mutable = NSMutableAttributedString(string: source)
-        let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
-        let range = NSRange(location: 0, length: mutable.string.utf16.count)
-        detector?.enumerateMatches(in: mutable.string, options: [], range: range) { match, _, _ in
-            guard let match, let url = match.url else { return }
-            mutable.addAttribute(.link, value: url, range: match.range)
+    /// The message rendered for display: parsed as Markdown when the publisher marked the
+    /// message `text/markdown` (via the `Markdown: true` header), otherwise shown as plain text.
+    /// Bare URLs are turned into tappable links in both cases. Rendering Markdown only when the
+    /// server opted in is deliberate — parsing arbitrary plain-text messages as Markdown would
+    /// mangle bodies that happen to contain `*`, `_`, `#`, etc.
+    func displayMessageAttributedString() -> AttributedString {
+        if isMarkdown, let markdown = markdownMessageAttributedString() {
+            return markdown
         }
-        
-        return AttributedString(mutable)
+        return linkifiedMessageAttributedString()
+    }
+
+    func linkifiedMessageAttributedString() -> AttributedString {
+        var attributed = AttributedString(formatMessage())
+        linkifyBareUrls(in: &attributed)
+        return attributed
+    }
+
+    /// Parses the message body as inline Markdown. Block elements (headings, lists, quotes) are
+    /// kept inline by SwiftUI's `Text`, which is the right fidelity for a compact notification row.
+    /// Returns nil if parsing fails, so the caller can fall back to plain text.
+    private func markdownMessageAttributedString() -> AttributedString? {
+        let source = formatMessage()
+        let options: AttributedString.MarkdownParsingOptions
+        if #available(iOS 16.0, *) {
+            // Preserve intentional line breaks (notifications are often multi-line).
+            options = .init(interpretedSyntax: .inlineOnlyPreservingWhitespace, failurePolicy: .returnPartiallyParsedIfPossible)
+        } else {
+            options = .init(interpretedSyntax: .inlineOnly, failurePolicy: .returnPartiallyParsedIfPossible)
+        }
+        guard var attributed = try? AttributedString(markdown: source, options: options) else {
+            return nil
+        }
+        linkifyBareUrls(in: &attributed)
+        return attributed
+    }
+}
+
+/// Detects URLs (e.g. `https://ntfy.sh`) in the text and turns them into tappable links, without
+/// overriding links already present — e.g. those produced by Markdown `[text](url)` syntax. Used
+/// for both the plain-text and Markdown rendering paths.
+private func linkifyBareUrls(in attributed: inout AttributedString) {
+    let plain = String(attributed.characters)
+    guard
+        !plain.isEmpty,
+        let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+    else { return }
+
+    let nsRange = NSRange(plain.startIndex..<plain.endIndex, in: plain)
+    detector.enumerateMatches(in: plain, options: [], range: nsRange) { match, _, _ in
+        guard
+            let match,
+            let url = match.url,
+            let stringRange = Range(match.range, in: plain),
+            let lower = AttributedString.Index(stringRange.lowerBound, within: attributed),
+            let upper = AttributedString.Index(stringRange.upperBound, within: attributed)
+        else { return }
+        let attributedRange = lower..<upper
+        if attributed[attributedRange].link == nil {
+            attributed[attributedRange].link = url
+        }
     }
 }
 

--- a/ntfy/Views/Notifications/NotificationRowView.swift
+++ b/ntfy/Views/Notifications/NotificationRowView.swift
@@ -110,7 +110,7 @@ struct NotificationRowView: View {
     
     private var messageText: some View {
         Group {
-            Text(notification.linkifiedMessageAttributedString())
+            Text(notification.displayMessageAttributedString())
                 .font(.body)
         }
     }


### PR DESCRIPTION
## Summary

Messages published with the `Markdown: true` header (content type `text/markdown`) are now rendered as formatted text on iOS instead of showing raw markup like `**bold**`. Implements binwiederhier/ntfy#1072.

Rendering is intentionally gated on the server's opt-in (`content_type`) — parsing every message as Markdown would mangle plain-text bodies that happen to contain `*`, `_`, `#`, etc.

### Capture the content type
- Decode the server's `content_type` on the wire (`Message`)
- Persist it on the `Notification` Core Data entity (new optional `contentType` attribute)
- Round-trip it through the FCM `userInfo` path used by the notification service extension

### In-app rendering
- Render `text/markdown` messages as inline Markdown in the notification list, plain text otherwise
- Bare URLs stay linkified in both paths (folded into a single helper)
- Native `AttributedString` Markdown parsing — no new dependency
- Whitespace preserved on iOS 16+, inline-only fallback on iOS 15

### Notification banner
- The banner can't render rich text (APNs), so for Markdown messages it shows clean plain text with the formatting markers stripped, instead of raw `**`

### Core Data
- Added an optional `contentType` attribute; relies on the already-enabled lightweight migration

## Relation to existing PRs

There are two earlier open Markdown PRs; this one is rebased on current `main` and credits both:

- **#30** (@AnimaI) — same core design (capture `content_type` → persist on `Notification` → render `AttributedString(markdown:)` gated on the opt-in). This PR extends that approach: it also strips Markdown in the notification banner (the service-extension path), keeps bare-URL linkification working alongside Markdown, splits the iOS 15 vs 16 whitespace handling, and is rebased on `main` after the `NotificationRowView` extraction.
- **#27** (@paule76) — an alternative that adds the MarkdownUI SPM dependency plus an in-app Safari browser for links. This PR instead uses the native `AttributedString` parser, with no new dependency.

Happy to defer to or fold in either if the maintainers prefer.

## Test plan
- [x] `git diff --check` is clean
- [x] Builds with `xcodebuild` against the iOS 26.5 SDK
- [ ] Subscribe to a topic, publish a Markdown message, and confirm it renders:
  ```
  curl -H "Markdown: true" -d $'**Bold**, *italic*, `code`, a [link](https://ntfy.sh)\n\n- one\n- two' ntfy.sh/<topic>
  ```
- [ ] In-app row renders bold / italic / code / links / list
- [ ] Banner shows clean plain text (no raw `**`)
- [ ] A plain-text message containing `*` / `_` / `#` is unaffected

Fixes binwiederhier/ntfy#1072
