### PR TITLE
Modernize UI and add cross-topic All Notifications view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ GoogleService-Info.plist
 ntfy.xcodeproj/xcuserdata
 ntfy.xcodeproj/project.xcworkspace/xcuserdata/
 .worktrees/
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 GoogleService-Info.plist
 ntfy.xcodeproj/xcuserdata
 ntfy.xcodeproj/project.xcworkspace/xcuserdata/
+.worktrees/

--- a/docs/superpowers/plans/2026-07-17-emoji-topic-avatar.md
+++ b/docs/superpowers/plans/2026-07-17-emoji-topic-avatar.md
@@ -1,0 +1,570 @@
+# Per-topic Emoji Avatar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the user set a custom emoji per subscribed topic, shown instead of the default colored initial-letter avatar on that topic's row in "Subscribed topics".
+
+**Architecture:** One new optional Core Data attribute (`Subscription.icon`), one new `Store` persistence method, an extension to the existing `TopicAvatarView` to render an emoji when present, and a new small sheet view (`TopicIconEditorView`) opened by tapping the avatar, which edits that attribute directly.
+
+**Tech Stack:** SwiftUI, Core Data (lightweight migration), no new dependencies.
+
+## Global Constraints
+
+- Applies only to topic rows in `SubscriptionListView`'s "Subscribed topics" list. Do not touch the "All Notifications" pinned row's icon or the topic-name badges inside the All Notifications feed.
+- No custom searchable emoji picker — rely on the native iOS emoji keyboard (user taps the field, then the globe/emoji key).
+- `nil`/empty `icon` means "no custom emoji" and must fall back to the existing colored initial-letter avatar exactly as it renders today.
+- This project has no XCTest target (`xcodebuild -list` shows only the `ntfy` and `ntfyNSE` schemes, no test target) — every task's verification step is a build check plus a concrete manual check, not an automated test.
+- Deployment target is iOS 16 (already set project-wide); avoid APIs newer than that unless already guarded elsewhere in the codebase the way `ContentUnavailableView` is (`#available(iOS 17.0, *)`).
+- Match existing code conventions exactly: `Store` mutation methods use `context.performAndWait { ...; try? context.save() }` (see `Store.swift:144` `delete(subscription:)` for the pattern); dismiss-style sheets use a "Done" button matching `SubscriptionAddView`/`UserEditorView`.
+
+---
+
+### Task 1: Add `icon` attribute to the Core Data model
+
+**Files:**
+- Modify: `ntfy/Persistence/ntfy.xcdatamodeld/Model.xcdatamodel/contents`
+
+**Interfaces:**
+- Produces: `Subscription.icon: String?` (Core Data codegen will synthesize this on the `Subscription` managed object class, matching how `Notification.isRead` was synthesized previously).
+
+- [ ] **Step 1: Add the attribute**
+
+In `ntfy/Persistence/ntfy.xcdatamodeld/Model.xcdatamodel/contents`, find the `Subscription` entity (currently lines 31-42):
+
+```xml
+    <entity name="Subscription" representedClassName="Subscription" syncable="YES" codeGenerationType="class">
+        <attribute name="baseUrl" attributeType="String"/>
+        <attribute name="lastNotificationId" optional="YES" attributeType="String"/>
+        <attribute name="topic" attributeType="String" minValueString="1" maxValueString="64" regularExpressionString="^[-_A-Za-z0-9]{1,64}$"/>
+        <relationship name="notifications" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Notification" inverseName="subscription" inverseEntity="Notification"/>
+```
+
+Change it to:
+
+```xml
+    <entity name="Subscription" representedClassName="Subscription" syncable="YES" codeGenerationType="class">
+        <attribute name="baseUrl" attributeType="String"/>
+        <attribute name="icon" optional="YES" attributeType="String"/>
+        <attribute name="lastNotificationId" optional="YES" attributeType="String"/>
+        <attribute name="topic" attributeType="String" minValueString="1" maxValueString="64" regularExpressionString="^[-_A-Za-z0-9]{1,64}$"/>
+        <relationship name="notifications" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Notification" inverseName="subscription" inverseEntity="Notification"/>
+```
+
+(Only the new `icon` line is added, alphabetically between `baseUrl` and `lastNotificationId`.)
+
+- [ ] **Step 2: Build to verify the migration compiles**
+
+Run: `cd /Users/hibikipr/Developer/ntfy-ios && xcodebuild build -scheme ntfy -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -quiet`
+
+Expected: exits with no output and status 0 (`echo $?` prints `0`). This confirms Core Data code generation picked up the new attribute and the app still compiles — no new model version file is needed since this is a lightweight migration (optional attribute, no default value required) and the store already has `shouldMigrateStoreAutomatically`/`shouldInferMappingModelAutomatically` enabled (`Store.swift:51-52`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/hibikipr/Developer/ntfy-ios
+git add ntfy/Persistence/ntfy.xcdatamodeld/Model.xcdatamodel/contents
+git commit -m "Add icon attribute to Subscription for per-topic emoji avatars"
+```
+
+---
+
+### Task 2: Add `Store.saveIcon(for:icon:)`
+
+**Files:**
+- Modify: `ntfy/Persistence/Store.swift`
+
+**Interfaces:**
+- Consumes: `Subscription.icon: String?` (Task 1).
+- Produces: `Store.saveIcon(for subscription: Subscription, icon: String?)` — later tasks call this exact signature.
+
+- [ ] **Step 1: Add the method**
+
+In `ntfy/Persistence/Store.swift`, find `getSubscriptions()` (currently lines 120-122):
+
+```swift
+    func getSubscriptions() -> [Subscription]? {
+        return try? context.fetch(Subscription.fetchRequest())
+    }
+```
+
+Add a new method directly after it:
+
+```swift
+    func getSubscriptions() -> [Subscription]? {
+        return try? context.fetch(Subscription.fetchRequest())
+    }
+
+    func saveIcon(for subscription: Subscription, icon: String?) {
+        context.performAndWait {
+            subscription.icon = (icon?.isEmpty ?? true) ? nil : icon
+            try? context.save()
+        }
+    }
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `cd /Users/hibikipr/Developer/ntfy-ios && xcodebuild build -scheme ntfy -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -quiet`
+
+Expected: exit status 0, no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/hibikipr/Developer/ntfy-ios
+git add ntfy/Persistence/Store.swift
+git commit -m "Add Store.saveIcon for persisting per-topic emoji"
+```
+
+---
+
+### Task 3: Extend `TopicAvatarView` to render an emoji
+
+**Files:**
+- Modify: `ntfy/Views/Subscriptions/SubscriptionListView.swift` (the `TopicAvatarView` struct, currently lines 259-282)
+
+**Interfaces:**
+- Produces: `TopicAvatarView(name: String, emoji: String? = nil)` — later tasks (Task 4) pass `subscription.icon` as `emoji`.
+
+- [ ] **Step 1: Update `TopicAvatarView`**
+
+Replace the current `TopicAvatarView` struct:
+
+```swift
+struct TopicAvatarView: View {
+    let name: String
+
+    private var initial: String {
+        String(name.first ?? "?").uppercased()
+    }
+
+    private var color: Color {
+        let hash = abs(name.hashValue)
+        let hue = Double(hash % 360) / 360.0
+        return Color(hue: hue, saturation: 0.55, brightness: 0.85)
+    }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(color)
+                .frame(width: 40, height: 40)
+            Text(initial)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(.white)
+        }
+    }
+}
+```
+
+with:
+
+```swift
+struct TopicAvatarView: View {
+    let name: String
+    var emoji: String? = nil
+
+    private var initial: String {
+        String(name.first ?? "?").uppercased()
+    }
+
+    private var color: Color {
+        let hash = abs(name.hashValue)
+        let hue = Double(hash % 360) / 360.0
+        return Color(hue: hue, saturation: 0.55, brightness: 0.85)
+    }
+
+    var body: some View {
+        if let emoji, !emoji.isEmpty {
+            Text(emoji)
+                .font(.system(size: 24))
+                .frame(width: 40, height: 40)
+        } else {
+            ZStack {
+                Circle()
+                    .fill(color)
+                    .frame(width: 40, height: 40)
+                Text(initial)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(.white)
+            }
+        }
+    }
+}
+```
+
+Note: the existing call site at `SubscriptionItemRowView`'s `TopicAvatarView(name: subscription.topicName())` (line 180) does not need to change in this task — `emoji` defaults to `nil`, so it keeps rendering exactly as before.
+
+- [ ] **Step 2: Build to verify it compiles and existing rows are unchanged**
+
+Run: `cd /Users/hibikipr/Developer/ntfy-ios && xcodebuild build -scheme ntfy -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -quiet`
+
+Expected: exit status 0, no output.
+
+Manual check: install and launch on the simulator —
+
+```bash
+xcrun simctl install "iPhone 17 Pro" /Users/hibikipr/Library/Developer/Xcode/DerivedData/ntfy-*/Build/Products/Debug-iphonesimulator/ntfy.app
+xcrun simctl launch "iPhone 17 Pro" io.heckel.ntfy
+xcrun simctl io "iPhone 17 Pro" screenshot /tmp/topic-avatars-unchanged.png
+```
+
+Open `/tmp/topic-avatars-unchanged.png` and confirm every topic row still shows its colored circle + initial letter exactly as before (no row has an `icon` set yet, so nothing should visually change).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/hibikipr/Developer/ntfy-ios
+git add ntfy/Views/Subscriptions/SubscriptionListView.swift
+git commit -m "Add emoji rendering support to TopicAvatarView"
+```
+
+---
+
+### Task 4: Wire `subscription.icon` into the row's avatar
+
+**Files:**
+- Modify: `ntfy/Views/Subscriptions/SubscriptionListView.swift` (the `SubscriptionItemRowView.body`, currently line 180)
+
+**Interfaces:**
+- Consumes: `TopicAvatarView(name:emoji:)` (Task 3), `Subscription.icon: String?` (Task 1).
+
+- [ ] **Step 1: Pass the icon through**
+
+In `SubscriptionItemRowView.body`, change:
+
+```swift
+        HStack(spacing: 12) {
+            TopicAvatarView(name: subscription.topicName())
+```
+
+to:
+
+```swift
+        HStack(spacing: 12) {
+            TopicAvatarView(name: subscription.topicName(), emoji: subscription.icon)
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `cd /Users/hibikipr/Developer/ntfy-ios && xcodebuild build -scheme ntfy -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -quiet`
+
+Expected: exit status 0, no output. There is still no way to set `icon` yet (that's Task 5-6), so behavior is unchanged until then — this task only wires the data flow.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/hibikipr/Developer/ntfy-ios
+git add ntfy/Views/Subscriptions/SubscriptionListView.swift
+git commit -m "Pass subscription.icon into the topic row's avatar"
+```
+
+---
+
+### Task 5: Build the `TopicIconEditorView` sheet
+
+**Files:**
+- Create: `ntfy/Views/Subscriptions/TopicIconEditorView.swift`
+
+**Interfaces:**
+- Consumes: `Store.saveIcon(for:icon:)` (Task 2), `TopicAvatarView(name:emoji:)` (Task 3).
+- Produces: `TopicIconEditorView(subscription: Subscription)` — Task 6 presents this in a `.sheet`.
+
+- [ ] **Step 1: Create the file**
+
+```swift
+import SwiftUI
+
+struct TopicIconEditorView: View {
+    @EnvironmentObject private var store: Store
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var subscription: Subscription
+    @State private var iconText: String
+
+    init(subscription: Subscription) {
+        self.subscription = subscription
+        _iconText = State(initialValue: subscription.icon ?? "")
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                TopicAvatarView(name: subscription.topicName(), emoji: iconText.isEmpty ? nil : iconText)
+                    .scaleEffect(2)
+                    .padding(.top, 24)
+
+                VStack(spacing: 8) {
+                    TextField("Emoji", text: $iconText)
+                        .multilineTextAlignment(.center)
+                        .font(.system(size: 32))
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 120)
+                        .onChange(of: iconText) { newValue in
+                            if let last = newValue.last {
+                                iconText = String(last)
+                            }
+                            store.saveIcon(for: subscription, icon: iconText)
+                        }
+
+                    Text("Tap the field, then tap the globe/emoji key on the keyboard to pick one.")
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 32)
+                }
+
+                Spacer()
+
+                if !iconText.isEmpty {
+                    Button(role: .destructive) {
+                        iconText = ""
+                        store.saveIcon(for: subscription, icon: nil)
+                    } label: {
+                        Text("Remove")
+                    }
+                    .padding(.bottom, 8)
+                }
+            }
+            .navigationTitle(subscription.topicName())
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct TopicIconEditorView_Previews: PreviewProvider {
+    static var previews: some View {
+        let store = Store.preview
+        let subscription = store.makeSubscription(store.context, "stats", Store.sampleMessages["stats"]!)
+        TopicIconEditorView(subscription: subscription)
+            .environment(\.managedObjectContext, store.context)
+            .environmentObject(store)
+    }
+}
+```
+
+Note on `onChange(of:)` signature: this file uses the single-parameter closure form (`{ newValue in ... }`), matching the iOS 16-compatible form already used elsewhere in this codebase (see `SubscriptionListView.swift`'s `.onChange(of: delegate.selectedBaseUrl) { newValue in ... }`).
+
+- [ ] **Step 2: Register the new file with the Xcode project**
+
+This project uses a manually-maintained `project.pbxproj` (no `PBXFileSystemSynchronizedRootGroup`), so new files must be registered by hand or Xcode won't compile them. Generate three unique 24-character hex IDs not already present in the file:
+
+```bash
+cd /Users/hibikipr/Developer/ntfy-ios
+for i in 1 2; do
+  id=$(python3 -c "import random; print(''.join(random.choice('0123456789ABCDEF') for _ in range(24)))")
+  grep -q "$id" ntfy.xcodeproj/project.pbxproj && echo "COLLISION, regenerate" || echo "$id"
+done
+```
+
+Using the two generated IDs (call them `FILEREF_ID` and `BUILDFILE_ID`), make these edits to `ntfy.xcodeproj/project.pbxproj`:
+
+1. Add a `PBXBuildFile` entry next to the existing `SubscriptionAddView.swift in Sources` entry (search for it to find the right section):
+```
+		<BUILDFILE_ID> /* TopicIconEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = <FILEREF_ID> /* TopicIconEditorView.swift */; };
+```
+
+2. Add a `PBXFileReference` entry next to `SubscriptionAddView.swift`'s file reference:
+```
+		<FILEREF_ID> /* TopicIconEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicIconEditorView.swift; sourceTree = "<group>"; };
+```
+
+3. Add `<FILEREF_ID> /* TopicIconEditorView.swift */,` to the `Subscriptions` `PBXGroup`'s `children` list (the group containing `SubscriptionAddView.swift` and `SubscriptionListView.swift`).
+
+4. Add `<BUILDFILE_ID> /* TopicIconEditorView.swift in Sources */,` to the `ntfy` target's `PBXSourcesBuildPhase` `files` list (search for `SubscriptionAddView.swift in Sources` inside the `Sources` phase and add the new line next to it).
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `cd /Users/hibikipr/Developer/ntfy-ios && xcodebuild build -scheme ntfy -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -quiet`
+
+Expected: exit status 0, no output. If you see `error: cannot find 'TopicIconEditorView' in scope` or similar, re-check Step 2 — a common mistake is missing the `Sources` build phase entry specifically.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/hibikipr/Developer/ntfy-ios
+git add ntfy/Views/Subscriptions/TopicIconEditorView.swift ntfy.xcodeproj/project.pbxproj
+git commit -m "Add TopicIconEditorView sheet for setting a topic's emoji"
+```
+
+---
+
+### Task 6: Open the editor from the avatar tap
+
+**Files:**
+- Modify: `ntfy/Views/Subscriptions/SubscriptionListView.swift` (the `SubscriptionItemRowView` struct, currently lines 158-212)
+
+**Interfaces:**
+- Consumes: `TopicIconEditorView(subscription:)` (Task 5).
+
+- [ ] **Step 1: Add sheet state and wrap the avatar in its own tap target**
+
+Replace the current `SubscriptionItemRowView`:
+
+```swift
+struct SubscriptionItemRowView: View {
+    @ObservedObject var subscription: Subscription
+    @StateObject private var notificationsModel: NotificationsObservable
+
+    init(subscription: Subscription) {
+        self.subscription = subscription
+        _notificationsModel = StateObject(wrappedValue: NotificationsObservable(subscriptionID: subscription.objectID))
+    }
+
+    private var isDefaultServer: Bool {
+        guard let baseUrl = subscription.baseUrl else { return true }
+        return normalizeBaseUrl(baseUrl) == normalizeBaseUrl(Config.appBaseUrl)
+    }
+
+    // notificationsModel.notifications is already sorted by time descending
+    private var unreadCount: Int {
+        notificationsModel.notifications.reduce(0) { $1.isRead ? $0 : $0 + 1 }
+    }
+
+    var body: some View {
+        let totalNotificationCount = notificationsModel.notifications.count
+        HStack(spacing: 12) {
+            TopicAvatarView(name: subscription.topicName(), emoji: subscription.icon)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text(subscription.topicName())
+                            .font(.headline)
+                            .lineLimit(1)
+                        if !isDefaultServer, let baseUrl = subscription.baseUrl {
+                            Text(shortUrl(url: baseUrl))
+                                .font(.caption)
+                                .foregroundColor(.gray)
+                                .lineLimit(1)
+                        }
+                    }
+                    Spacer()
+                    Text(notificationsModel.notifications.first?.shortDateTime() ?? "")
+                        .font(.subheadline)
+                        .foregroundColor(.gray)
+                }
+                HStack {
+                    Text("\(totalNotificationCount) notification\(totalNotificationCount != 1 ? "s" : "")")
+                        .font(.subheadline)
+                        .foregroundColor(.gray)
+                    if unreadCount > 0 {
+                        Spacer()
+                        UnreadDotView()
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+```
+
+with:
+
+```swift
+struct SubscriptionItemRowView: View {
+    @ObservedObject var subscription: Subscription
+    @StateObject private var notificationsModel: NotificationsObservable
+    @State private var showIconEditor = false
+
+    init(subscription: Subscription) {
+        self.subscription = subscription
+        _notificationsModel = StateObject(wrappedValue: NotificationsObservable(subscriptionID: subscription.objectID))
+    }
+
+    private var isDefaultServer: Bool {
+        guard let baseUrl = subscription.baseUrl else { return true }
+        return normalizeBaseUrl(baseUrl) == normalizeBaseUrl(Config.appBaseUrl)
+    }
+
+    // notificationsModel.notifications is already sorted by time descending
+    private var unreadCount: Int {
+        notificationsModel.notifications.reduce(0) { $1.isRead ? $0 : $0 + 1 }
+    }
+
+    var body: some View {
+        let totalNotificationCount = notificationsModel.notifications.count
+        HStack(spacing: 12) {
+            Button {
+                showIconEditor = true
+            } label: {
+                TopicAvatarView(name: subscription.topicName(), emoji: subscription.icon)
+            }
+            .buttonStyle(.plain)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text(subscription.topicName())
+                            .font(.headline)
+                            .lineLimit(1)
+                        if !isDefaultServer, let baseUrl = subscription.baseUrl {
+                            Text(shortUrl(url: baseUrl))
+                                .font(.caption)
+                                .foregroundColor(.gray)
+                                .lineLimit(1)
+                        }
+                    }
+                    Spacer()
+                    Text(notificationsModel.notifications.first?.shortDateTime() ?? "")
+                        .font(.subheadline)
+                        .foregroundColor(.gray)
+                }
+                HStack {
+                    Text("\(totalNotificationCount) notification\(totalNotificationCount != 1 ? "s" : "")")
+                        .font(.subheadline)
+                        .foregroundColor(.gray)
+                    if unreadCount > 0 {
+                        Spacer()
+                        UnreadDotView()
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 4)
+        .sheet(isPresented: $showIconEditor) {
+            TopicIconEditorView(subscription: subscription)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `cd /Users/hibikipr/Developer/ntfy-ios && xcodebuild build -scheme ntfy -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -quiet`
+
+Expected: exit status 0, no output.
+
+- [ ] **Step 3: Manual end-to-end verification**
+
+This step needs a human with touch/accessibility access to the simulator or a device — the agent sandbox used earlier in this project's history had no tap/UI automation available, so this cannot be scripted. Install and launch the app, then:
+
+1. Tap the avatar circle on any topic row. **Expected:** the `TopicIconEditorView` sheet opens (not the topic's notification list).
+2. Tap elsewhere on that same row (the topic name or timestamp). **Expected:** it still navigates into the topic's notification list as before.
+3. In the sheet, tap the text field, switch to the emoji keyboard (globe/emoji key), and pick an emoji. **Expected:** the preview avatar at the top of the sheet updates immediately to show that emoji with no colored background.
+4. Tap "Done". **Expected:** back on "Subscribed topics", that topic's row now shows the emoji instead of the colored letter.
+5. Pick a multi-codepoint emoji (e.g. a flag or a family emoji with skin tone modifiers). **Expected:** it displays as one complete glyph, not a broken/partial character.
+6. Re-open the editor on that topic and tap "Remove". **Expected:** the preview reverts to the colored letter avatar, and the "Remove" button itself disappears (it's only shown when an icon is set).
+7. Tap "Done". **Expected:** the topic row on "Subscribed topics" now shows the colored letter avatar again.
+8. Confirm no other topic's avatar changed in this process.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/hibikipr/Developer/ntfy-ios
+git add ntfy/Views/Subscriptions/SubscriptionListView.swift
+git commit -m "Open TopicIconEditorView when tapping a topic's avatar"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** data model (Task 1), persistence (Task 2), row rendering fallback (Task 3), wiring (Task 4), editor sheet incl. remove/done (Task 5), entry point via avatar tap (Task 6) — all spec sections have a task.
+- **Type consistency:** `Store.saveIcon(for:icon:)` (Task 2) is called with that exact signature in `TopicIconEditorView` (Task 5). `TopicAvatarView(name:emoji:)` (Task 3) is called with that exact signature in Task 4 and Task 5/6. `TopicIconEditorView(subscription:)` (Task 5) is called with that exact signature in Task 6.
+- **No test target:** every task substitutes a build check plus a concrete manual verification for the automated test cycle this skill normally prescribes, since the project has no XCTest target and adding one is out of scope for this feature.

--- a/docs/superpowers/specs/2026-07-17-emoji-topic-avatar-design.md
+++ b/docs/superpowers/specs/2026-07-17-emoji-topic-avatar-design.md
@@ -1,0 +1,69 @@
+# Per-topic emoji avatar
+
+## Context
+
+Topic rows in "Subscribed topics" show a colored circle with the topic's initial letter (`TopicAvatarView`), added as part of the UI modernization work in PR #49 / binwiederhier#49. The user wants to optionally replace that with a custom emoji per topic, picked by hand, so topics are more visually distinguishable at a glance than a single letter allows.
+
+## Scope
+
+- Applies to topic rows in `SubscriptionListView`'s "Subscribed topics" list only.
+- Does **not** apply to the "All Notifications" pinned row (keeps its fixed `tray.full.fill` icon) or to the topic-name badges shown per-message inside the All Notifications feed (`NotificationRowView`'s `subscriptionLabel` capsule) — those are out of scope.
+- No custom in-app searchable emoji grid. The app already bundles a full gemoji dataset (`EmojiManager`, `emojis.json`) used for parsing emoji tags in messages, but this feature relies on the native iOS emoji keyboard instead, to keep the picker UI minimal.
+
+## Data model
+
+Add an optional attribute to the `Subscription` entity in `ntfy.xcdatamodeld`:
+
+```xml
+<attribute name="icon" optional="YES" attributeType="String"/>
+```
+
+`nil`/empty means "no custom emoji — use the default colored initial-letter avatar." This is a lightweight Core Data migration (optional, no default value needed), consistent with how `isRead` was added to `Notification` previously. No new model version is required; `shouldMigrateStoreAutomatically`/`shouldInferMappingModelAutomatically` are already enabled on the store.
+
+## Persistence
+
+Add a `Store` method, following the existing pattern of other subscription/preference setters (e.g. `saveUser`, `saveDefaultBaseUrl`):
+
+```swift
+func saveIcon(for subscription: Subscription, icon: String?) {
+    context.performAndWait {
+        subscription.icon = (icon?.isEmpty ?? true) ? nil : icon
+        try? context.save()
+    }
+}
+```
+
+## Row rendering
+
+`TopicAvatarView` gains an optional `emoji: String?` parameter:
+- When non-nil/non-empty: render just the emoji character, centered, no colored background (the emoji already carries its own color), same 40×40 footprint as today.
+- When nil/empty: unchanged existing behavior — colored circle (hash-derived hue) with the topic's uppercased initial letter.
+
+`SubscriptionItemRowView` passes `subscription.icon` into `TopicAvatarView`.
+
+## Entry point
+
+The avatar becomes its own tap target: wrap it in a `Button(action: { showEmojiEditor = true })` with `.buttonStyle(.plain)`, nested inside the row's content. Since the row itself sits inside `NavigationLink(value: NotificationsRoute.topic(subscription))` (in `SubscriptionItemNavView`), the inner `Button` intercepts its own tap and does not also trigger navigation — tapping anywhere else on the row still opens the topic as today.
+
+## Emoji editor sheet
+
+New view, e.g. `TopicIconEditorView`, presented via `.sheet(isPresented: $showEmojiEditor)` from `SubscriptionItemRowView` (or its parent nav view — whichever ends up holding the `@State` cleanly during implementation). Contents:
+
+- A live preview of the avatar as currently configured (reuses `TopicAvatarView`).
+- A single-character `TextField` bound to a local `@State` string. On any change, truncate to the **last** entered `Character` (Swift's `Character` is grapheme-cluster-aware, so multi-codepoint emoji — flags, ZWJ family sequences, skin-tone modifiers — stay intact as one unit) and immediately persist via `store.saveIcon(for:icon:)`. No separate "Save" step.
+- A hint label: "Tap the field, then tap the globe/emoji key to pick one" (iOS has no dedicated "emoji-only" `UIKeyboardType`, so the user switches keyboards manually).
+- A **Remove** button/action, shown only when an icon is currently set, that clears it (`store.saveIcon(for: subscription, icon: nil)`) and reverts the preview to the default letter avatar.
+- A **Done** button to dismiss the sheet (matching the dismiss pattern already used by `SubscriptionAddView`/`UserEditorView`).
+
+## Out of scope / non-goals
+
+- No validation that the entered character is "actually an emoji" — if a user types a plain letter, it just renders as that letter with no background circle (harmless, not worth guarding against).
+- No bulk/import/export of icons, no default emoji suggestions, no per-server or per-notification icons.
+
+## Testing
+
+- Manual: set an emoji on a topic, confirm the row shows it immediately (no colored background) and other rows are unaffected.
+- Manual: set a multi-codepoint emoji (e.g. family or flag emoji) and confirm it isn't truncated to a broken partial glyph.
+- Manual: remove an emoji and confirm the row reverts to the colored initial-letter avatar.
+- Manual: confirm tapping the avatar opens the sheet without also navigating into the topic, and tapping elsewhere on the row still navigates normally.
+- Build: `xcodebuild build` for the iOS Simulator after the model change, to confirm the lightweight migration compiles and the app launches against an existing store without a crash.

--- a/ntfy.xcodeproj/project.pbxproj
+++ b/ntfy.xcodeproj/project.pbxproj
@@ -70,6 +70,8 @@
 		94E9196C28353E0100F30170 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9474F216283531A200CDE4DD /* Log.swift */; };
 		E27008102AF0F64B006E33BA /* SubscriptionsObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E270080F2AF0F64B006E33BA /* SubscriptionsObservable.swift */; };
 		E27008122AF1030A006E33BA /* NotificationsObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27008112AF1030A006E33BA /* NotificationsObservable.swift */; };
+		0DCB5CEC6E2932E1CF7233F7 /* AllNotificationsObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA38E1571685600864FEC94 /* AllNotificationsObservable.swift */; };
+		ED0F611CB30B5739F9F707C9 /* AllNotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 657B5A8147018ECD39100744 /* AllNotificationsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -148,6 +150,8 @@
 		94CD1969283E666900973B93 /* EmojiManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmojiManager.swift; sourceTree = "<group>"; };
 		E270080F2AF0F64B006E33BA /* SubscriptionsObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionsObservable.swift; sourceTree = "<group>"; };
 		E27008112AF1030A006E33BA /* NotificationsObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsObservable.swift; sourceTree = "<group>"; };
+		2DA38E1571685600864FEC94 /* AllNotificationsObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllNotificationsObservable.swift; sourceTree = "<group>"; };
+		657B5A8147018ECD39100744 /* AllNotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllNotificationsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -201,6 +205,7 @@
 				29E841A12FB417EA00F927E4 /* NotificationAttachmentSectionView.swift */,
 				29E841A22FB417EA00F927E4 /* NotificationListView.swift */,
 				29E841A32FB417EA00F927E4 /* NotificationRowView.swift */,
+				657B5A8147018ECD39100744 /* AllNotificationsView.swift */,
 			);
 			path = Notifications;
 			sourceTree = "<group>";
@@ -286,6 +291,7 @@
 				2968F2AC2FBA530200480665 /* AttachmentProgressState.swift */,
 				29E8419F2FB417EA00F927E4 /* NotificationAttachmentImageLoader.swift */,
 				E27008112AF1030A006E33BA /* NotificationsObservable.swift */,
+				2DA38E1571685600864FEC94 /* AllNotificationsObservable.swift */,
 				94A3F7C7283734D900C48E79 /* SubscriptionManager.swift */,
 				E270080F2AF0F64B006E33BA /* SubscriptionsObservable.swift */,
 				9407EDD9284ADE1F00C1C334 /* User.swift */,
@@ -472,6 +478,8 @@
 				9474F1F72830830700CDE4DD /* ntfy.xcdatamodeld in Sources */,
 				29E841A52FB417EA00F927E4 /* NotificationAttachmentController.swift in Sources */,
 				29E841A62FB417EA00F927E4 /* NotificationRowView.swift in Sources */,
+				ED0F611CB30B5739F9F707C9 /* AllNotificationsView.swift in Sources */,
+				0DCB5CEC6E2932E1CF7233F7 /* AllNotificationsObservable.swift in Sources */,
 				29B4EB062FD7C5C1005CA516 /* CriticalAlertsSettingView.swift in Sources */,
 				29E841A72FB417EA00F927E4 /* NotificationAttachmentImageLoader.swift in Sources */,
 				29E841A82FB417EA00F927E4 /* NotificationAttachmentImageView.swift in Sources */,
@@ -567,7 +575,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -622,7 +630,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -653,7 +661,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -688,7 +696,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -713,7 +721,7 @@
 				INFOPLIST_FILE = ntfyNSE/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ntfyNSE;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -740,7 +748,7 @@
 				INFOPLIST_FILE = ntfyNSE/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ntfyNSE;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ntfy.xcodeproj/project.pbxproj
+++ b/ntfy.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		29C6D8322FBD1B750057C9AC /* DownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C6D8302FBD1B750057C9AC /* DownloadDelegate.swift */; };
 		29E8419B2FB417E400F927E4 /* SubscriptionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29E841992FB417E400F927E4 /* SubscriptionListView.swift */; };
 		29E8419C2FB417E400F927E4 /* SubscriptionAddView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29E841982FB417E400F927E4 /* SubscriptionAddView.swift */; };
+		258B5053A8C14C1477993609 /* TopicIconEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE8DE340E147766BAA25874 /* TopicIconEditorView.swift */; };
 		29E841A52FB417EA00F927E4 /* NotificationAttachmentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29E8419E2FB417EA00F927E4 /* NotificationAttachmentController.swift */; };
 		29E841A62FB417EA00F927E4 /* NotificationRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29E841A32FB417EA00F927E4 /* NotificationRowView.swift */; };
 		29E841A72FB417EA00F927E4 /* NotificationAttachmentImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29E8419F2FB417EA00F927E4 /* NotificationAttachmentImageLoader.swift */; };
@@ -111,6 +112,7 @@
 		29B4EB052FD7C5C1005CA516 /* CriticalAlertsSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CriticalAlertsSettingView.swift; sourceTree = "<group>"; };
 		29C6D8302FBD1B750057C9AC /* DownloadDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadDelegate.swift; sourceTree = "<group>"; };
 		29E841982FB417E400F927E4 /* SubscriptionAddView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionAddView.swift; sourceTree = "<group>"; };
+		CBE8DE340E147766BAA25874 /* TopicIconEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicIconEditorView.swift; sourceTree = "<group>"; };
 		29E841992FB417E400F927E4 /* SubscriptionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionListView.swift; sourceTree = "<group>"; };
 		29E8419D2FB417EA00F927E4 /* AttachmentFileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentFileStore.swift; sourceTree = "<group>"; };
 		29E8419E2FB417EA00F927E4 /* NotificationAttachmentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAttachmentController.swift; sourceTree = "<group>"; };
@@ -192,6 +194,7 @@
 			isa = PBXGroup;
 			children = (
 				29E841982FB417E400F927E4 /* SubscriptionAddView.swift */,
+				CBE8DE340E147766BAA25874 /* TopicIconEditorView.swift */,
 				29E841992FB417E400F927E4 /* SubscriptionListView.swift */,
 			);
 			path = Subscriptions;
@@ -464,6 +467,7 @@
 				9474F1D2282F2D2C00CDE4DD /* AppDelegate.swift in Sources */,
 				29E8419B2FB417E400F927E4 /* SubscriptionListView.swift in Sources */,
 				29E8419C2FB417E400F927E4 /* SubscriptionAddView.swift in Sources */,
+				258B5053A8C14C1477993609 /* TopicIconEditorView.swift in Sources */,
 				94A3F7CA28386B2100C48E79 /* Config.swift in Sources */,
 				9474F1C3282F2AA700CDE4DD /* ContentView.swift in Sources */,
 				9474F20C283321C300CDE4DD /* Notification.swift in Sources */,

--- a/ntfy/Persistence/AllNotificationsObservable.swift
+++ b/ntfy/Persistence/AllNotificationsObservable.swift
@@ -1,45 +1,38 @@
 import CoreData
 import SwiftUI
 
-class NotificationsObservable: NSObject, ObservableObject {
-    private let tag = "NotificationsObservable"
-    private var subscriptionID: NSManagedObjectID
-    
+class AllNotificationsObservable: NSObject, ObservableObject {
+    private let tag = "AllNotificationsObservable"
+
     private lazy var fetchedResultsController: NSFetchedResultsController<Notification> = {
         let fetchRequest: NSFetchRequest<Notification> = Notification.fetchRequest()
-        
-        // Filter by the desired subscription
-        fetchRequest.predicate = NSPredicate(format: "subscription == %@", subscriptionID)
-        
-        // Sort descriptors if you need them
-        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "time", ascending: false)] // Assuming you have a 'date' attribute on the NotificationEntity
-        
+        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "time", ascending: false)]
+
         let controller = NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: Store.shared.context, sectionNameKeyPath: nil, cacheName: nil)
         controller.delegate = self
         return controller
     }()
-    
+
     @Published var notifications: [Notification] = []
-    
-    init(subscriptionID: NSManagedObjectID) {
-        self.subscriptionID = subscriptionID
+
+    override init() {
         super.init()
-        
+
         do {
-            Log.d(tag, "Fetching notifications")
+            Log.d(tag, "Fetching all notifications")
             try self.fetchedResultsController.performFetch()
             self.notifications = self.fetchedResultsController.fetchedObjects ?? []
         } catch {
-            Log.w(tag, "Failed to fetch notifications \(error)")
+            Log.w(tag, "Failed to fetch all notifications \(error)")
         }
     }
 }
 
-extension NotificationsObservable: NSFetchedResultsControllerDelegate {
+extension AllNotificationsObservable: NSFetchedResultsControllerDelegate {
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
         let fetched = self.fetchedResultsController.fetchedObjects ?? []
         let unread = fetched.filter { !$0.isRead }.count
-        Log.d(tag, "Content changed for subscription \(subscriptionID), count=\(fetched.count), unread=\(unread)")
+        Log.d(tag, "Content changed, count=\(fetched.count), unread=\(unread)")
         DispatchQueue.main.async {
             withAnimation {
                 self.notifications = fetched

--- a/ntfy/Persistence/Store.swift
+++ b/ntfy/Persistence/Store.swift
@@ -232,6 +232,36 @@ class Store: ObservableObject {
             }
         }
     }
+
+    func deleteAllNotifications() {
+        context.performAndWait {
+            guard let notifications = try? context.fetch(Notification.fetchRequest()) else { return }
+            Log.d(Store.tag, "Deleting all \(notifications.count) notification(s) across all subscriptions")
+            do {
+                notifications.forEach { notification in
+                    deleteAttachmentLocalFile(for: notification)
+                    context.delete(notification)
+                }
+                try context.save()
+            } catch let error {
+                Log.w(Store.tag, "Cannot delete notification(s)", error)
+                rollbackAndRefresh()
+            }
+        }
+    }
+
+    func markRead(_ notification: Notification) {
+        guard !notification.isRead else { return }
+        context.performAndWait {
+            notification.isRead = true
+            do {
+                try context.save()
+                Log.d(Store.tag, "Marked notification \(notification.id ?? "?") as read")
+            } catch {
+                Log.w(Store.tag, "Failed to save isRead for notification \(notification.id ?? "?")", error)
+            }
+        }
+    }
     
     // MARK: Users
     

--- a/ntfy/Persistence/Store.swift
+++ b/ntfy/Persistence/Store.swift
@@ -121,6 +121,13 @@ class Store: ObservableObject {
         return try? context.fetch(Subscription.fetchRequest())
     }
 
+    func saveIcon(for subscription: Subscription, icon: String?) {
+        context.performAndWait {
+            subscription.icon = (icon?.isEmpty ?? true) ? nil : icon
+            try? context.save()
+        }
+    }
+
     func completeAttachmentDownload(notificationID: String, localPath: String, resolvedType: String?, resolvedSize: Int64) {
         context.performAndWait {
             let request = Notification.fetchRequest()

--- a/ntfy/Persistence/Subscription.swift
+++ b/ntfy/Persistence/Subscription.swift
@@ -16,17 +16,4 @@ extension Subscription {
     func urlHash() -> String {
         return topicHash(baseUrl: baseUrl ?? "?", topic: topic ?? "?")
     }
-    
-    func notificationCount() -> Int {
-        return notifications?.count ?? 0
-    }
-    
-    func lastNotification() -> Notification? {
-        guard let notifications else {
-            return nil
-        }
-        return notifications
-            .sortedArray(using: [NSSortDescriptor(keyPath: \Notification.time, ascending: false)])
-            .first as? Notification
-    }
 }

--- a/ntfy/Persistence/SubscriptionsObservable.swift
+++ b/ntfy/Persistence/SubscriptionsObservable.swift
@@ -54,7 +54,9 @@ extension SubscriptionsObservable: NSFetchedResultsControllerDelegate {
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
         Log.d(tag, "Fetching notifications")
         DispatchQueue.main.async {
-            self.objectWillChange.send()
+            withAnimation {
+                self.objectWillChange.send()
+            }
         }
     }
 }

--- a/ntfy/Persistence/ntfy.xcdatamodeld/Model.xcdatamodel/contents
+++ b/ntfy/Persistence/ntfy.xcdatamodeld/Model.xcdatamodel/contents
@@ -11,6 +11,7 @@
         <attribute name="attachmentUrl" optional="YES" attributeType="String"/>
         <attribute name="click" optional="YES" attributeType="String"/>
         <attribute name="id" attributeType="String"/>
+        <attribute name="isRead" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="message" attributeType="String"/>
         <attribute name="priority" optional="YES" attributeType="Integer 16" minValueString="1" maxValueString="5" defaultValueString="3" usesScalarValueType="YES"/>
         <attribute name="tags" optional="YES" attributeType="String"/>

--- a/ntfy/Persistence/ntfy.xcdatamodeld/Model.xcdatamodel/contents
+++ b/ntfy/Persistence/ntfy.xcdatamodeld/Model.xcdatamodel/contents
@@ -30,6 +30,7 @@
     </entity>
     <entity name="Subscription" representedClassName="Subscription" syncable="YES" codeGenerationType="class">
         <attribute name="baseUrl" attributeType="String"/>
+        <attribute name="icon" optional="YES" attributeType="String"/>
         <attribute name="lastNotificationId" optional="YES" attributeType="String"/>
         <attribute name="topic" attributeType="String" minValueString="1" maxValueString="64" regularExpressionString="^[-_A-Za-z0-9]{1,64}$"/>
         <relationship name="notifications" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Notification" inverseName="subscription" inverseEntity="Notification"/>

--- a/ntfy/Views/Extensions.swift
+++ b/ntfy/Views/Extensions.swift
@@ -21,13 +21,8 @@ extension Notification {
 
 struct DisableAutocapitalizationModifier: ViewModifier {
     func body(content: Content) -> some View {
-        if #available(iOS 15.0, *) {
-            content
-                .textInputAutocapitalization(.never)
-        } else {
-            content
-                .autocapitalization(.none)
-        }
+        content
+            .textInputAutocapitalization(.never)
     }
 }
 

--- a/ntfy/Views/MainView.swift
+++ b/ntfy/Views/MainView.swift
@@ -2,6 +2,12 @@ import Foundation
 import SwiftUI
 
 struct MainView: View {
+    @StateObject private var allNotificationsModel = AllNotificationsObservable()
+
+    private var unreadCount: Int {
+        allNotificationsModel.notifications.reduce(0) { $1.isRead ? $0 : $0 + 1 }
+    }
+
     var body: some View {
         TabView {
             SubscriptionListView()
@@ -9,6 +15,7 @@ struct MainView: View {
                     Image(systemName: "message.fill")
                     Text("Notifications")
                 }
+                .badge(unreadCount)
             SettingsView()
                 .tabItem {
                     Image(systemName: "gearshape.fill")

--- a/ntfy/Views/Notifications/AllNotificationsView.swift
+++ b/ntfy/Views/Notifications/AllNotificationsView.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+import UserNotifications
+
+struct AllNotificationsView: View {
+    private let tag = "AllNotificationsView"
+
+    @EnvironmentObject private var store: Store
+    @StateObject var notificationsModel = AllNotificationsObservable()
+
+    @State private var searchText = ""
+    @State private var showClearAllAlert = false
+
+    private var filteredNotifications: [Notification] {
+        guard !searchText.isEmpty else {
+            return notificationsModel.notifications
+        }
+        return notificationsModel.notifications.filter {
+            $0.formatMessage().localizedCaseInsensitiveContains(searchText) ||
+            ($0.formatTitle()?.localizedCaseInsensitiveContains(searchText) ?? false)
+        }
+    }
+
+    var body: some View {
+        List {
+            ForEach(filteredNotifications, id: \.self) { notification in
+                NotificationRowView(
+                    notification: notification,
+                    onCopyMessage: {},
+                    subscriptionLabel: notification.subscription?.topicName()
+                )
+            }
+        }
+        .listStyle(.insetGrouped)
+        .searchable(text: $searchText, prompt: "Search notifications")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                Text("All Notifications")
+                    .font(.headline)
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                if notificationsModel.notifications.count > 0 {
+                    Button("Clear all") {
+                        showClearAllAlert = true
+                    }
+                }
+            }
+        }
+        .overlay {
+            if notificationsModel.notifications.isEmpty {
+                emptyState
+            }
+        }
+        .alert("Clear all notifications", isPresented: $showClearAllAlert) {
+            Button("Permanently delete", role: .destructive) {
+                UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                store.deleteAllNotifications()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Do you really want to delete all of the notifications across every topic?")
+        }
+        .onAppear {
+            cancelAllDeliveredNotifications()
+        }
+        .refreshable {
+            pollAllSubscriptions()
+        }
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        if #available(iOS 17.0, *) {
+            ContentUnavailableView(
+                "No notifications yet",
+                systemImage: "bell.slash",
+                description: Text("Notifications from all of your subscribed topics will show up here.")
+            )
+        } else {
+            VStack {
+                Text("You haven't received any notifications yet.")
+                    .font(.title2)
+                    .foregroundColor(.gray)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(40)
+        }
+    }
+
+    private func cancelAllDeliveredNotifications() {
+        UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+    }
+
+    private func pollAllSubscriptions() {
+        let subscriptionManager = SubscriptionManager(store: store)
+        store.getSubscriptions()?.forEach { subscription in
+            subscriptionManager.poll(subscription)
+        }
+    }
+}
+
+struct AllNotificationsView_Previews: PreviewProvider {
+    static var previews: some View {
+        let store = Store.preview
+        NavigationStack {
+            AllNotificationsView()
+        }
+        .environment(\.managedObjectContext, store.context)
+        .environmentObject(store)
+    }
+}

--- a/ntfy/Views/Notifications/NotificationListView.swift
+++ b/ntfy/Views/Notifications/NotificationListView.swift
@@ -14,22 +14,23 @@ struct NotificationListView: View {
     @EnvironmentObject private var store: Store
     
     @ObservedObject var subscription: Subscription
-    @ObservedObject var notificationsModel: NotificationsObservable
-    
+    @StateObject private var notificationsModel: NotificationsObservable
+
     @State private var editMode = EditMode.inactive
     @State private var selection = Set<Notification>()
-    
+
     @State private var showAlert = false
     @State private var activeAlert: ActiveAlert = .clear
     @State private var showCopiedConfirmation = false
-    
+    @State private var searchText = ""
+
     private var subscriptionManager: SubscriptionManager {
         return SubscriptionManager(store: store)
     }
-    
+
     init(subscription: Subscription) {
         self.subscription = subscription
-        self.notificationsModel = NotificationsObservable(subscriptionID: subscription.objectID)
+        _notificationsModel = StateObject(wrappedValue: NotificationsObservable(subscriptionID: subscription.objectID))
     }
 
     var body: some View {
@@ -51,7 +52,8 @@ struct NotificationListView: View {
                 }
             }
         }
-        .listStyle(PlainListStyle())
+        .listStyle(.insetGrouped)
+        .searchable(text: $searchText, prompt: "Search notifications")
         .navigationBarTitleDisplayMode(.inline)
         .environment(\.editMode, self.$editMode)
         .toolbar {
@@ -130,21 +132,11 @@ struct NotificationListView: View {
                     secondaryButton: .cancel())
             }
         }
-        .overlay(Group {
-            if notificationsModel.notifications.count == 0 {
-                VStack {
-                    Text("You haven't received any notifications for this topic yet.")
-                        .font(.title2)
-                        .foregroundColor(.gray)
-                        .multilineTextAlignment(.center)
-                        .padding(.bottom)
-                    
-                    Text("To send notifications to this topic, simply PUT or POST to the topic URL.\n\nExample:\n`$ curl -d \"hi\" ntfy.sh/\(subscription.topicName())`\n\nDetailed instructions are available on [ntfy.sh](https://ntfy.sh) and [in the docs](https://ntfy.sh/docs).")
-                        .foregroundColor(.gray)
-                }
-                .padding(40)
+        .overlay {
+            if notificationsModel.notifications.isEmpty {
+                emptyState
             }
-        })
+        }
         .overlay(Group {
             if showCopiedConfirmation {
                 Text("Copied to Clipboard")
@@ -171,11 +163,44 @@ struct NotificationListView: View {
     
     @ViewBuilder
     private var notificationRows: some View {
-        ForEach(notificationsModel.notifications, id: \.self) { notification in
+        ForEach(filteredNotifications, id: \.self) { notification in
             NotificationRowView(
                 notification: notification,
                 onCopyMessage: showCopyConfirmation
             )
+        }
+    }
+
+    private var filteredNotifications: [Notification] {
+        guard !searchText.isEmpty else {
+            return notificationsModel.notifications
+        }
+        return notificationsModel.notifications.filter {
+            $0.formatMessage().localizedCaseInsensitiveContains(searchText) ||
+            ($0.formatTitle()?.localizedCaseInsensitiveContains(searchText) ?? false)
+        }
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        if #available(iOS 17.0, *) {
+            ContentUnavailableView {
+                Label("No notifications yet", systemImage: "bell.slash")
+            } description: {
+                Text("To send notifications to this topic, simply PUT or POST to the topic URL.\n\nExample:\n`$ curl -d \"hi\" ntfy.sh/\(subscription.topicName())`\n\nDetailed instructions are available on [ntfy.sh](https://ntfy.sh) and [in the docs](https://ntfy.sh/docs).")
+            }
+        } else {
+            VStack {
+                Text("You haven't received any notifications for this topic yet.")
+                    .font(.title2)
+                    .foregroundColor(.gray)
+                    .multilineTextAlignment(.center)
+                    .padding(.bottom)
+
+                Text("To send notifications to this topic, simply PUT or POST to the topic URL.\n\nExample:\n`$ curl -d \"hi\" ntfy.sh/\(subscription.topicName())`\n\nDetailed instructions are available on [ntfy.sh](https://ntfy.sh) and [in the docs](https://ntfy.sh/docs).")
+                    .foregroundColor(.gray)
+            }
+            .padding(40)
         }
     }
     
@@ -223,15 +248,18 @@ struct NotificationListView: View {
     }
     
     private func unsubscribe() {
+        UINotificationFeedbackGenerator().notificationOccurred(.warning)
         subscriptionManager.unsubscribe(subscription)
         delegate.selectedBaseUrl = nil
     }
-    
+
     private func deleteAll() {
+        UINotificationFeedbackGenerator().notificationOccurred(.warning)
         store.delete(allNotificationsFor: subscription)
     }
-    
+
     private func deleteSelected() {
+        UINotificationFeedbackGenerator().notificationOccurred(.warning)
         store.delete(notifications: selection)
         selection = Set<Notification>()
         editMode = .inactive

--- a/ntfy/Views/Notifications/NotificationRowView.swift
+++ b/ntfy/Views/Notifications/NotificationRowView.swift
@@ -14,17 +14,22 @@ struct NotificationRowView: View {
     @Environment(\.openURL) private var openURL
     @ObservedObject var notification: Notification
     let onCopyMessage: () -> Void
+    var subscriptionLabel: String? = nil
     @StateObject private var attachmentController = NotificationAttachmentController()
     @State private var attachmentPresentation: AttachmentPresentation?
-    
+
     var body: some View {
         notificationRow
             .swipeActions(edge: .trailing) {
                 Button(role: .destructive) {
+                    UINotificationFeedbackGenerator().notificationOccurred(.success)
                     store.delete(notification: notification)
                 } label: {
                     Label("Delete", systemImage: "trash.circle")
                 }
+            }
+            .onAppear {
+                store.markRead(notification)
             }
             .sheet(item: $attachmentPresentation) { attachmentPresentation in
                 switch attachmentPresentation.mode {
@@ -50,6 +55,15 @@ struct NotificationRowView: View {
                                 .scaledToFit()
                                 .frame(width: 16, height: 16)
                         }
+                    }
+                    if let subscriptionLabel {
+                        Text(subscriptionLabel)
+                            .font(.caption)
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 2)
+                            .background(Color.accentColor)
+                            .clipShape(Capsule())
                     }
                     Spacer()
                     if clickUrl != nil {

--- a/ntfy/Views/Settings/DefaultServerView.swift
+++ b/ntfy/Views/Settings/DefaultServerView.swift
@@ -40,7 +40,7 @@ struct DefaultServerView: View {
             .contentShape(Rectangle())
         }
         .sheet(isPresented: $showDialog) {
-            NavigationView {
+            NavigationStack {
                 Form {
                     Section(
                         footer: Text("When subscribing to new topics, this server will be used as a default. Note that if you pick your own ntfy server, you must configure upstream-base-url to receive instant push notifications.")

--- a/ntfy/Views/Settings/SettingsView.swift
+++ b/ntfy/Views/Settings/SettingsView.swift
@@ -8,7 +8,7 @@ struct SettingsView: View {
     @State private var userDialog: UserDialog?
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             Form {
                 Section(
                     header: Text("General"),
@@ -55,7 +55,6 @@ struct SettingsView: View {
                 }
             )
         }
-        .navigationViewStyle(StackNavigationViewStyle())
     }
 }
 

--- a/ntfy/Views/Settings/UserEditorView.swift
+++ b/ntfy/Views/Settings/UserEditorView.swift
@@ -35,7 +35,7 @@ struct UserEditorView: View {
     }
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             Form {
                 Section(
                     footer: isNewUser
@@ -66,16 +66,10 @@ struct UserEditorView: View {
                             Button("Cancel") {
                                 onCancel()
                             }
-                            if #available(iOS 15.0, *) {
-                                Button(role: .destructive) {
-                                    deleteAction()
-                                } label: {
-                                    Text("Delete")
-                                }
-                            } else {
-                                Button("Delete") {
-                                    deleteAction()
-                                }
+                            Button(role: .destructive) {
+                                deleteAction()
+                            } label: {
+                                Text("Delete")
                             }
                         } label: {
                             Image(systemName: "ellipsis.circle")

--- a/ntfy/Views/Subscriptions/SubscriptionAddView.swift
+++ b/ntfy/Views/Subscriptions/SubscriptionAddView.swift
@@ -23,20 +23,11 @@ struct SubscriptionAddView: View {
     }
     
     var body: some View {
-        NavigationView {
-            // This is a little weird, but it works. The nagivation link for the login view
-            // is rendered in the backgroun (it's hidden), abd we toggle it manually.
-            // If anyone has a better way to do a two-page layout let me know.
-            
+        NavigationStack {
             addView
-                .background(Group {
-                    NavigationLink(
-                        destination: loginView,
-                        isActive: $showLogin
-                    ) {
-                        EmptyView()
-                    }
-                })
+                .navigationDestination(isPresented: $showLogin) {
+                    loginView
+                }
         }
     }
     

--- a/ntfy/Views/Subscriptions/SubscriptionListView.swift
+++ b/ntfy/Views/Subscriptions/SubscriptionListView.swift
@@ -258,6 +258,7 @@ struct AllNotificationsRowView: View {
 
 struct TopicAvatarView: View {
     let name: String
+    var emoji: String? = nil
 
     private var initial: String {
         String(name.first ?? "?").uppercased()
@@ -270,13 +271,19 @@ struct TopicAvatarView: View {
     }
 
     var body: some View {
-        ZStack {
-            Circle()
-                .fill(color)
+        if let emoji, !emoji.isEmpty {
+            Text(emoji)
+                .font(.system(size: 24))
                 .frame(width: 40, height: 40)
-            Text(initial)
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundColor(.white)
+        } else {
+            ZStack {
+                Circle()
+                    .fill(color)
+                    .frame(width: 40, height: 40)
+                Text(initial)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(.white)
+            }
         }
     }
 }

--- a/ntfy/Views/Subscriptions/SubscriptionListView.swift
+++ b/ntfy/Views/Subscriptions/SubscriptionListView.swift
@@ -158,6 +158,7 @@ struct SubscriptionItemNavView: View {
 struct SubscriptionItemRowView: View {
     @ObservedObject var subscription: Subscription
     @StateObject private var notificationsModel: NotificationsObservable
+    @State private var showIconEditor = false
 
     init(subscription: Subscription) {
         self.subscription = subscription
@@ -177,7 +178,12 @@ struct SubscriptionItemRowView: View {
     var body: some View {
         let totalNotificationCount = notificationsModel.notifications.count
         HStack(spacing: 12) {
-            TopicAvatarView(name: subscription.topicName(), emoji: subscription.icon)
+            Button {
+                showIconEditor = true
+            } label: {
+                TopicAvatarView(name: subscription.topicName(), emoji: subscription.icon)
+            }
+            .buttonStyle(.plain)
             VStack(alignment: .leading, spacing: 2) {
                 HStack(alignment: .top) {
                     VStack(alignment: .leading, spacing: 0) {
@@ -208,6 +214,9 @@ struct SubscriptionItemRowView: View {
             }
         }
         .padding(.vertical, 4)
+        .sheet(isPresented: $showIconEditor) {
+            TopicIconEditorView(subscription: subscription)
+        }
     }
 }
 

--- a/ntfy/Views/Subscriptions/SubscriptionListView.swift
+++ b/ntfy/Views/Subscriptions/SubscriptionListView.swift
@@ -280,15 +280,14 @@ struct TopicAvatarView: View {
     }
 
     var body: some View {
-        if let emoji, !emoji.isEmpty {
-            Text(emoji)
-                .font(.system(size: 24))
+        ZStack {
+            Circle()
+                .fill(color)
                 .frame(width: 40, height: 40)
-        } else {
-            ZStack {
-                Circle()
-                    .fill(color)
-                    .frame(width: 40, height: 40)
+            if let emoji, !emoji.isEmpty {
+                Text(emoji)
+                    .font(.system(size: 20))
+            } else {
                 Text(initial)
                     .font(.system(size: 16, weight: .semibold))
                     .foregroundColor(.white)

--- a/ntfy/Views/Subscriptions/SubscriptionListView.swift
+++ b/ntfy/Views/Subscriptions/SubscriptionListView.swift
@@ -177,7 +177,7 @@ struct SubscriptionItemRowView: View {
     var body: some View {
         let totalNotificationCount = notificationsModel.notifications.count
         HStack(spacing: 12) {
-            TopicAvatarView(name: subscription.topicName())
+            TopicAvatarView(name: subscription.topicName(), emoji: subscription.icon)
             VStack(alignment: .leading, spacing: 2) {
                 HStack(alignment: .top) {
                     VStack(alignment: .leading, spacing: 0) {

--- a/ntfy/Views/Subscriptions/SubscriptionListView.swift
+++ b/ntfy/Views/Subscriptions/SubscriptionListView.swift
@@ -3,47 +3,66 @@ import CoreData
 import FirebaseMessaging
 import UserNotifications
 
+enum NotificationsRoute: Hashable {
+    case all
+    case topic(Subscription)
+}
+
 struct SubscriptionListView: View {
     let tag = "SubscriptionList"
-    
+
     @EnvironmentObject private var store: Store
-    @ObservedObject var subscriptionsModel = SubscriptionsObservable()
+    @EnvironmentObject private var delegate: AppDelegate
+    @StateObject var subscriptionsModel = SubscriptionsObservable()
+    @StateObject var allNotificationsModel = AllNotificationsObservable()
     @State private var showingAddDialog = false
-    
+    @State private var path: [NotificationsRoute] = []
+
     private var subscriptionManager: SubscriptionManager {
         return SubscriptionManager(store: store)
     }
-    
+
     var body: some View {
-        NavigationView {
-            if #available(iOS 15.0, *) {
-                subscriptionList
-                    .refreshable {
-                        pollSubscriptions()
+        NavigationStack(path: $path) {
+            subscriptionList
+                .navigationDestination(for: NotificationsRoute.self) { route in
+                    switch route {
+                    case .all:
+                        AllNotificationsView()
+                    case .topic(let subscription):
+                        NotificationListView(subscription: subscription)
                     }
-            } else {
-                subscriptionList
-                    .toolbar {
-                        ToolbarItem(placement: .navigationBarLeading) {
-                            Button {
-                                pollSubscriptions()
-                            } label: {
-                                Image(systemName: "arrow.clockwise")
-                            }
-                        }
-                    }
-            }
+                }
         }
-        .navigationViewStyle(StackNavigationViewStyle())
+        .onChange(of: delegate.selectedBaseUrl) { newValue in
+            guard
+                let newValue,
+                let subscription = subscriptionsModel.subscriptions.first(where: { $0.urlString() == newValue })
+            else {
+                return
+            }
+            path = [.topic(subscription)]
+        }
     }
-    
+
     private var subscriptionList: some View {
         List {
+            if !subscriptionsModel.subscriptions.isEmpty {
+                NavigationLink(value: NotificationsRoute.all) {
+                    AllNotificationsRowView(
+                        notificationsModel: allNotificationsModel,
+                        topicCount: subscriptionsModel.subscriptions.count
+                    )
+                }
+            }
             ForEach(subscriptionsModel.subscriptions) { subscription in
                 SubscriptionItemNavView(subscription: subscription)
             }
         }
-        .listStyle(PlainListStyle())
+        .listStyle(.insetGrouped)
+        .refreshable {
+            pollSubscriptions()
+        }
         .navigationTitle("Subscribed topics")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
@@ -54,32 +73,40 @@ struct SubscriptionListView: View {
                 }
             }
         }
-        .overlay(Group {
+        .overlay {
             if subscriptionsModel.subscriptions.isEmpty {
-                VStack {
-                    Text("It looks like you don't have any subscriptions yet")
-                        .font(.title2)
-                        .foregroundColor(.gray)
-                        .multilineTextAlignment(.center)
-                        .padding(.bottom)
-
-                    if #available(iOS 15.0, *) {
-                        Text("Click the + to create or subscribe to a topic. Afterwards, you receive notifications on your device when sending messages via PUT or POST.\n\nDetailed instructions are available on [ntfy.sh](https://ntfy.sh) and [in the docs](https://ntfy.sh/docs).")
-                            .foregroundColor(.gray)
-                    } else {
-                        Text("Click the + to create or subscribe to a topic. Afterwards, you receive notifications on your device when sending messages via PUT or POST.\n\nDetailed instructions are available on https://ntfy.sh and https://ntfy.sh/docs")
-                            .foregroundColor(.gray)
-                    }
-                }
-                .padding(40)
+                emptyState
             }
-        })
+        }
         .sheet(isPresented: $showingAddDialog) {
             SubscriptionAddView(isShowing: $showingAddDialog)
         }
         .onAppear {
             // Ensures subscription count stays up to date, so a pull to refresh isn't required
             pollSubscriptions()
+        }
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        if #available(iOS 17.0, *) {
+            ContentUnavailableView {
+                Label("No subscriptions yet", systemImage: "tray")
+            } description: {
+                Text("Tap + to subscribe to a topic. You'll get notified whenever a message is sent to it via PUT or POST.\n\nDetailed instructions are available on [ntfy.sh](https://ntfy.sh) and [in the docs](https://ntfy.sh/docs).")
+            }
+        } else {
+            VStack {
+                Text("It looks like you don't have any subscriptions yet")
+                    .font(.title2)
+                    .foregroundColor(.gray)
+                    .multilineTextAlignment(.center)
+                    .padding(.bottom)
+
+                Text("Click the + to create or subscribe to a topic. Afterwards, you receive notifications on your device when sending messages via PUT or POST.\n\nDetailed instructions are available on [ntfy.sh](https://ntfy.sh) and [in the docs](https://ntfy.sh/docs).")
+                    .foregroundColor(.gray)
+            }
+            .padding(40)
         }
     }
 
@@ -92,42 +119,23 @@ struct SubscriptionListView: View {
 
 struct SubscriptionItemNavView: View {
     @EnvironmentObject private var store: Store
-    @EnvironmentObject private var delegate: AppDelegate
     @ObservedObject var subscription: Subscription
     @State private var unsubscribeAlert = false
-    
+
     private var subscriptionManager: SubscriptionManager {
         return SubscriptionManager(store: store)
     }
-    
+
     var body: some View {
-        if #available(iOS 15.0, *) {
-            subscriptionRow
-                .swipeActions(edge: .trailing) {
-                    Button(role: .destructive) {
-                        self.unsubscribeAlert = true
-                    } label: {
-                        Label("Delete", systemImage: "trash.circle")
-                    }
-                }
-        } else {
-            subscriptionRow
-        }
-    }
-    
-    private var subscriptionRow: some View {
-        ZStack {
-            NavigationLink(
-                destination: NotificationListView(subscription: subscription),
-                tag: subscription.urlString(),
-                selection: $delegate.selectedBaseUrl
-            ) {
-                EmptyView()
-            }
-            .opacity(0.0)
-            .buttonStyle(PlainButtonStyle())
-            
+        NavigationLink(value: NotificationsRoute.topic(subscription)) {
             SubscriptionItemRowView(subscription: subscription)
+        }
+        .swipeActions(edge: .trailing) {
+            Button(role: .destructive) {
+                self.unsubscribeAlert = true
+            } label: {
+                Label("Delete", systemImage: "trash.circle")
+            }
         }
         .alert(isPresented: $unsubscribeAlert) {
             Alert(
@@ -136,6 +144,7 @@ struct SubscriptionItemNavView: View {
                 primaryButton: .destructive(
                     Text("Unsubscribe"),
                     action: {
+                        UINotificationFeedbackGenerator().notificationOccurred(.warning)
                         self.subscriptionManager.unsubscribe(subscription)
                         self.unsubscribeAlert = false
                     }
@@ -148,29 +157,135 @@ struct SubscriptionItemNavView: View {
 
 struct SubscriptionItemRowView: View {
     @ObservedObject var subscription: Subscription
-    
+    @StateObject private var notificationsModel: NotificationsObservable
+
+    init(subscription: Subscription) {
+        self.subscription = subscription
+        _notificationsModel = StateObject(wrappedValue: NotificationsObservable(subscriptionID: subscription.objectID))
+    }
+
+    private var isDefaultServer: Bool {
+        guard let baseUrl = subscription.baseUrl else { return true }
+        return normalizeBaseUrl(baseUrl) == normalizeBaseUrl(Config.appBaseUrl)
+    }
+
+    // notificationsModel.notifications is already sorted by time descending
+    private var unreadCount: Int {
+        notificationsModel.notifications.reduce(0) { $1.isRead ? $0 : $0 + 1 }
+    }
+
     var body: some View {
-        let totalNotificationCount = subscription.notificationCount()
-        VStack(alignment: .leading, spacing: 0) {
-            HStack {
-                Text(subscription.displayName())
-                    .font(.headline)
-                    .bold()
-                    .lineLimit(1)
-                Spacer()
-                Text(subscription.lastNotification()?.shortDateTime() ?? "")
-                    .font(.subheadline)
-                    .foregroundColor(.gray)
-                Image(systemName: "chevron.forward")
-                    .font(.system(size: 12.0))
-                    .foregroundColor(.gray)
+        let totalNotificationCount = notificationsModel.notifications.count
+        HStack(spacing: 12) {
+            TopicAvatarView(name: subscription.topicName())
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text(subscription.topicName())
+                            .font(.headline)
+                            .lineLimit(1)
+                        if !isDefaultServer, let baseUrl = subscription.baseUrl {
+                            Text(shortUrl(url: baseUrl))
+                                .font(.caption)
+                                .foregroundColor(.gray)
+                                .lineLimit(1)
+                        }
+                    }
+                    Spacer()
+                    Text(notificationsModel.notifications.first?.shortDateTime() ?? "")
+                        .font(.subheadline)
+                        .foregroundColor(.gray)
+                }
+                HStack {
+                    Text("\(totalNotificationCount) notification\(totalNotificationCount != 1 ? "s" : "")")
+                        .font(.subheadline)
+                        .foregroundColor(.gray)
+                    if unreadCount > 0 {
+                        Spacer()
+                        UnreadDotView()
+                    }
+                }
             }
-            Spacer()
-            Text("\(totalNotificationCount) notification\(totalNotificationCount != 1 ? "s" : "")")
-                .font(.subheadline)
-                .foregroundColor(.gray)
         }
-        .padding(.all, 4)
+        .padding(.vertical, 4)
+    }
+}
+
+struct AllNotificationsRowView: View {
+    @ObservedObject var notificationsModel: AllNotificationsObservable
+    let topicCount: Int
+
+    private var unreadCount: Int {
+        notificationsModel.notifications.reduce(0) { $1.isRead ? $0 : $0 + 1 }
+    }
+
+    var body: some View {
+        let notifications = notificationsModel.notifications
+        HStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(Color.accentColor)
+                    .frame(width: 40, height: 40)
+                Image(systemName: "tray.full.fill")
+                    .foregroundColor(.white)
+                    .font(.system(size: 16))
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    Text("All Notifications")
+                        .font(.headline)
+                        .lineLimit(1)
+                    Spacer()
+                    // notifications is already sorted by time descending
+                    Text(notifications.first?.shortDateTime() ?? "")
+                        .font(.subheadline)
+                        .foregroundColor(.gray)
+                }
+                HStack {
+                    Text("\(notifications.count) notification\(notifications.count != 1 ? "s" : "") across \(topicCount) topic\(topicCount != 1 ? "s" : "")")
+                        .font(.subheadline)
+                        .foregroundColor(.gray)
+                    if unreadCount > 0 {
+                        Spacer()
+                        UnreadDotView()
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+struct TopicAvatarView: View {
+    let name: String
+
+    private var initial: String {
+        String(name.first ?? "?").uppercased()
+    }
+
+    private var color: Color {
+        let hash = abs(name.hashValue)
+        let hue = Double(hash % 360) / 360.0
+        return Color(hue: hue, saturation: 0.55, brightness: 0.85)
+    }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(color)
+                .frame(width: 40, height: 40)
+            Text(initial)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(.white)
+        }
+    }
+}
+
+struct UnreadDotView: View {
+    var body: some View {
+        Circle()
+            .fill(Color.accentColor)
+            .frame(width: 8, height: 8)
     }
 }
 

--- a/ntfy/Views/Subscriptions/TopicIconEditorView.swift
+++ b/ntfy/Views/Subscriptions/TopicIconEditorView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+struct TopicIconEditorView: View {
+    @EnvironmentObject private var store: Store
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var subscription: Subscription
+    @State private var iconText: String
+
+    init(subscription: Subscription) {
+        self.subscription = subscription
+        _iconText = State(initialValue: subscription.icon ?? "")
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                TopicAvatarView(name: subscription.topicName(), emoji: iconText.isEmpty ? nil : iconText)
+                    .scaleEffect(2)
+                    .padding(.top, 24)
+
+                VStack(spacing: 8) {
+                    TextField("Emoji", text: $iconText)
+                        .multilineTextAlignment(.center)
+                        .font(.system(size: 32))
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 120)
+                        .onChange(of: iconText) { newValue in
+                            if let last = newValue.last {
+                                iconText = String(last)
+                            }
+                            store.saveIcon(for: subscription, icon: iconText)
+                        }
+
+                    Text("Tap the field, then tap the globe/emoji key on the keyboard to pick one.")
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 32)
+                }
+
+                Spacer()
+
+                if !iconText.isEmpty {
+                    Button(role: .destructive) {
+                        iconText = ""
+                        store.saveIcon(for: subscription, icon: nil)
+                    } label: {
+                        Text("Remove")
+                    }
+                    .padding(.bottom, 8)
+                }
+            }
+            .navigationTitle(subscription.topicName())
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct TopicIconEditorView_Previews: PreviewProvider {
+    static var previews: some View {
+        let store = Store.preview
+        let subscription = store.makeSubscription(store.context, "stats", Store.sampleMessages["stats"]!)
+        TopicIconEditorView(subscription: subscription)
+            .environment(\.managedObjectContext, store.context)
+            .environmentObject(store)
+    }
+}


### PR DESCRIPTION
Adds a merged, chronological feed across every subscribed topic (mirroring the ntfy web app's sidebar), pinned above the topic list, and refreshes the app's overall look and feel:

- Migrate navigation from NavigationView/tag-selection to NavigationStack with a typed Route enum, including the push-notification deep link path
- Add AllNotificationsObservable + AllNotificationsView for the merged feed, with per-row topic badges, search, and "clear all"
- Redesign topic/notification rows: insetGrouped lists, colored initial-letter avatars, ContentUnavailableView empty states (iOS 17, with iOS 16 fallback)
- Add isRead tracking (new Core Data attribute) with unread badges on the tab bar, topic rows, and the All Notifications row
- Add search to per-topic and all-notifications lists
- Animate list updates and add haptics on destructive actions
- Raise deployment target to iOS 16, dropping now-dead iOS 14/15 shims

Also fixes three bugs found during testing, all traced to the same class of issue: locally-created Core Data observers (SubscriptionsObservable, NotificationsObservable, AllNotificationsObservable) were declared @ObservedObject instead of @StateObject, so they got silently rebuilt (losing live-update state) on unrelated parent re-renders. Switching them to @StateObject, and having the All Notifications row observe its model directly instead of via a derived array, fixed a stale aggregate count, a non-updating unread dot, and made read-state changes propagate reliably across per-topic, aggregate, and tab-badge indicators. Also fixes topic names being truncated by the full host+topic string in row titles.